### PR TITLE
MRC-538: remove use of context/queuer

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,7 +7,6 @@
 ^notes\.md$
 ^rrq_.*\.tar\.gz$
 ^ignore$
-^tests/testthat/contexts$
 ^extra$
 ^\.lintr$
 ^TODO\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 .Rproj.user
 .Rhistory
 .RData
-tests/testthat/contexts
-tests/testthat/*.log
-tests/testthat/logs
 rrq_*.tar.gz
 extra/benchmark.html
 extra/benchmark.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ services:
   - redis-server
 
 r_github_packages:
-  - mrc-ide/context
-  - mrc-ide/queuer
   - richfitz/heartbeatr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ URL: https://github.com/mrc-ide/rrq
 BugReports: https://github.com/mrc-ide/rrq/issues
 Imports:
     R6,
-    context (>= 0.1.4),
     docopt,
     ids,
     lazyeval,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
     docopt,
     ids,
     lazyeval,
-    queuer (>= 0.1.0),
     redux (>= 1.0.0)
 Suggests:
     heartbeatr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     redux (>= 1.0.0)
 Suggests:
     heartbeatr,
+    storr,
     testthat
 RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     docopt,
     ids,
     lazyeval,
+    progress,
     redux (>= 1.0.0)
 Suggests:
     heartbeatr,

--- a/R/expression.R
+++ b/R/expression.R
@@ -4,6 +4,10 @@ expression_eval_safely <- function(expr, envir) {
 
   handler <- function(e) {
     e$trace <- trace$get()
+    w <- warnings$get()
+    if (length(w) > 0) {
+      e$warnings <- w
+    }
     class(e) <- c("rrq_task_error", class(e))
     e
   }
@@ -16,6 +20,127 @@ expression_eval_safely <- function(expr, envir) {
     error = handler)
 
   list(value = value,
-       success = !inherits(value, "rrq_task_error"),
-       warnings = warnings$get())
+       success = !inherits(value, "rrq_task_error"))
+}
+
+
+## Preparing an expression for remote evaluation.  There are lots of
+## ways that this can be done really.
+##
+## In context we try to set up an environment that is replicated
+## elsewhere and that gives an environment that we can query for the
+## existance of values.  We analyse the expression to work out what
+## might be needed, looking for symbols because we want to evaluate
+## the actual expression.
+##
+## The future package takes a similar approach - analyse an expression
+## and work out what is likely to be present.  It allows specification
+## of a "globals" argument to fine tune this.
+##
+## For a nice mix of flexibility here, we should offer a few modes I think:
+##
+## * do no analysis of the expression
+## * export an explicit list of variables to the environment
+## * ignore a specific list of variables
+## * automatically analyse an expression
+##
+## This function was derived from context::prepare_expression
+##
+## Once this works we will split it apart for use within the call()
+## and then bulk functions too.
+expression_prepare <- function(expr, envir_call, envir_base, db,
+                               analyse = TRUE, include = NULL, exclude = NULL,
+                               function_value = NULL) {
+  ret <- list(expr = expr)
+
+  if (!is.null(function_value)) {
+    assert_is(function_value, "function")
+    hash <- db$set_by_value(function_value, "objects")
+    ret$function_hash <- hash
+    ret$expr[[1L]] <- as.name(hash)
+  }
+
+  objects <- list()
+  if (analyse) {
+    symbols <- expression_find_symbols(expr)
+    if (length(symbols) > 0L) {
+      is_local <- vlapply(symbols, exists, envir_call, inherits = FALSE,
+                          USE.NAMES = FALSE)
+
+      if (!is.null(envir_base) && any(!is_local)) {
+        test <- symbols[!is_local]
+        is_in_base <- vlapply(test, exists, envir_base, USE.NAMES = FALSE)
+        if (any(!is_in_base)) {
+          stop("not all objects found: ",
+               paste(test[!is_in_base], collapse = ", "))
+        }
+      }
+
+      if (any(is_local)) {
+        collect <- symbols[is_local]
+        objects <- set_names(
+          lapply(collect, get, envir_call, inherits = FALSE),
+          collect)
+      }
+    }
+  }
+
+  if (length(include) > 0L) {
+    msg <- setdiff(include, names(objects))
+    objects[msg] <- lapply(msg, get, envir_call, inherits = TRUE)
+  }
+
+  if (length(exclude) > 0L) {
+    objects <- objects[!(names(objects) %in% exclude)]
+  }
+
+  if (length(objects) > 0L) {
+    h <- db$mset_by_value(objects, "objects")
+    ret$objects <- set_names(h, names(objects))
+  }
+
+  ret
+}
+
+
+expression_find_symbols <- function(expr) {
+  symbols <- collector()
+  namespace <- quote(`::`)
+  hidden <- quote(`:::`)
+  dollar <- quote(`$`)
+  stop_at <- c(namespace, hidden, dollar)
+
+  descend <- function(e) {
+    if (!is.recursive(e)) {
+      if (is.symbol(e)) {
+        symbols$add(deparse(e))
+      }
+    } else if (!is_call(e, stop_at)) {
+      for (a in as.list(e)) {
+        if (!missing(a)) {
+          descend(a)
+        }
+      }
+    }
+  }
+
+  if (!is.call(expr) || identical(expr[[1]], quote(`::`))) {
+    stop("Expected a call")
+  }
+
+  descend(expr[-1L])
+  unique(symbols$get())
+}
+
+
+expression_restore_locals <- function(dat, parent, db) {
+  e <- new.env(parent = parent)
+  objects <- dat$objects
+  if (!is.null(dat$function_hash)) {
+    objects <- c(objects, set_names(dat$function_hash, dat$function_hash))
+  }
+  if (length(dat$objects) > 0L) {
+    db$export(e, objects, "objects")
+  }
+  e
 }

--- a/R/expression.R
+++ b/R/expression.R
@@ -1,0 +1,22 @@
+expression_eval_safely <- function(expr, envir) {
+  warnings <- collector()
+  error <- NULL
+
+  handler <- function(e) {
+    e$trace <- utils::limitedLabels(sys.calls())
+    class(e) <- c("rrq_task_error", class(e))
+    error <<- e
+    NULL
+  }
+
+  value <- tryCatch(
+    withCallingHandlers(
+      eval(expr, envir),
+      warning = function(e) warnings$add(e$message),
+      error = function(e) handler(e)),
+    error = function(e) error)
+
+  list(value = value,
+       success = is.null(error),
+       warnings = warnings$get())
+}

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -65,7 +65,7 @@ R6_rrq_controller <- R6::R6Class(
     },
 
     enqueue_ = function(expr, envir = parent.frame(), key_complete = NULL) {
-      dat <- context::prepare_expression(expr, envir, self$db)
+      dat <- expression_prepare(expr, envir, NULL, self$db)
       task_submit(self$con, self$keys, dat, key_complete)
     },
 

--- a/R/time.R
+++ b/R/time.R
@@ -1,23 +1,13 @@
 ## Adapted from queuer
-time_checker <- function(timeout, remaining = FALSE) {
+time_checker <- function(timeout) {
   stopifnot(is.numeric(timeout) && length(timeout == 1))
   t0 <- Sys.time()
   timeout <- as.difftime(timeout, units = "secs")
   if (is.finite(timeout)) {
-    if (remaining) {
-      function() {
-        as.double(timeout - (Sys.time() - t0), "secs")
-      }
-    } else {
-      function() {
-        Sys.time() - t0 > timeout
-      }
+    function() {
+      as.double(timeout - (Sys.time() - t0), "secs")
     }
   } else {
-    if (remaining) {
-      function() Inf
-    } else {
-      function() FALSE
-    }
+    function() Inf
   }
 }

--- a/R/time.R
+++ b/R/time.R
@@ -1,0 +1,23 @@
+## Adapted from queuer
+time_checker <- function(timeout, remaining = FALSE) {
+  stopifnot(is.numeric(timeout) && length(timeout == 1))
+  t0 <- Sys.time()
+  timeout <- as.difftime(timeout, units = "secs")
+  if (is.finite(timeout)) {
+    if (remaining) {
+      function() {
+        as.double(timeout - (Sys.time() - t0), "secs")
+      }
+    } else {
+      function() {
+        Sys.time() - t0 > timeout
+      }
+    }
+  } else {
+    if (remaining) {
+      function() Inf
+    } else {
+      function() FALSE
+    }
+  }
+}

--- a/R/time.R
+++ b/R/time.R
@@ -11,3 +11,53 @@ time_checker <- function(timeout) {
     function() Inf
   }
 }
+
+
+progress_timeout <- function(total, show, label, timeout, ...) {
+  show <- show_progress(show)
+  time_left <- time_checker(timeout)
+  if (show) {
+    single <- total == 1
+    forever <- !is.finite(timeout)
+
+    if (single) {
+      ## Assume that we have the most simple pluralisation. This
+      ## happens to work for all our cases, but is not generally true
+      ## of course.
+      label <- sub("s$", "", label)
+      label_prefix <- sprintf("(:spin) waiting for %s", label)
+    } else {
+      label_prefix <- sprintf("(:spin) [:bar] :percent %s", label)
+    }
+    if (forever) {
+      label_suffix <- "waited for :elapsed"
+    } else {
+      label_suffix <- "giving up in :remaining s"
+    }
+    fmt <- sprintf("%s | %s", label_prefix, label_suffix)
+    p <- progress::progress_bar$new(fmt, total = total, show_after = 0,
+                                    ...)$tick
+
+    function(len = 1, ..., clear = FALSE) {
+      rem <- max(0, time_left())
+      move <- if (clear || rem == 0) total else if (single) 0L else len
+      if (forever) {
+        p(move)
+      } else {
+        width <- max(0, floor(log10(timeout))) + 1
+        remaining <- formatC(rem, digits = 0, width = width, format = "f")
+        p(move, tokens = list(remaining = remaining))
+      }
+      rem <= 0
+    }
+  } else {
+    function(...) {
+      time_left() <= 0
+    }
+  }
+}
+
+
+show_progress <- function(show) {
+  show %||% getOption("rrq.progress", interactive())
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,8 +92,7 @@ general_poll <- function(fetch, time_poll, timeout, name, error, progress) {
   done <- fetch()
 
   if (timeout > 0) {
-    p <- queuer::progress_timeout(length(done), show = progress,
-                                  timeout = timeout, show_after = 0)
+    p <- progress_timeout(length(done), progress, name, timeout)
     tot <- sum(done)
     p(tot)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,3 +117,14 @@ general_poll <- function(fetch, time_poll, timeout, name, error, progress) {
 
   done
 }
+
+
+collector <- function(init = character(0)) {
+  env <- new.env(parent = emptyenv())
+  env$res <- init
+  add <- function(x) {
+    env$res <- c(env$res, x)
+  }
+  list(add = add,
+       get = function() env$res)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -128,3 +128,8 @@ collector <- function(init = character(0)) {
   list(add = add,
        get = function() env$res)
 }
+
+
+is_call <- function(expr, what) {
+  is.call(expr) && any(vlapply(what, identical, expr[[1L]]))
+}

--- a/R/worker.R
+++ b/R/worker.R
@@ -125,6 +125,14 @@ R6_rrq_worker <- R6::R6Class(
       worker_format(self)
     },
 
+    timer_start = function() {
+      if (is.null(self$timeout)) {
+        self$timer <- NULL
+      } else {
+        self$timer <- time_checker(self$timeout)
+      }
+    },
+
     shutdown = function(status = "OK", graceful = TRUE) {
       if (!is.null(self$heartbeat)) {
         self$log("HEARTBEAT", "stopping")
@@ -220,7 +228,7 @@ worker_step <- function(worker, immediate) {
 
   if (is.null(task) && !is.null(worker$timeout)) {
     if (is.null(worker$timer)) {
-      worker$timer <- time_checker(worker$timeout, remaining = TRUE)
+      worker$timer_start()
     }
     if (worker$timer() < 0L) {
       stop(rrq_worker_stop(worker, "TIMEOUT"))

--- a/R/worker.R
+++ b/R/worker.R
@@ -220,7 +220,7 @@ worker_step <- function(worker, immediate) {
 
   if (is.null(task) && !is.null(worker$timeout)) {
     if (is.null(worker$timer)) {
-      worker$timer <- queuer::time_checker(worker$timeout, remaining = TRUE)
+      worker$timer <- time_checker(worker$timeout, remaining = TRUE)
     }
     if (worker$timer() < 0L) {
       stop(rrq_worker_stop(worker, "TIMEOUT"))

--- a/R/worker.R
+++ b/R/worker.R
@@ -304,7 +304,9 @@ worker_catch_interrupt <- function(worker) {
 
     task_running <- worker$con$HGET(worker$keys$worker_task, worker$name)
     if (!is.null(task_running)) {
-      worker_run_task_cleanup(worker, task_running, TASK_INTERRUPTED)
+      key_complete <- worker$con$HGET(worker$keys$task_complete, task_running)
+      worker_run_task_cleanup(worker, task_running, TASK_INTERRUPTED, NULL,
+                              key_complete)
     }
 
     ## There are two ways that interrupt happens (ignoring the

--- a/R/worker_messages.R
+++ b/R/worker_messages.R
@@ -87,7 +87,7 @@ run_message_TIMEOUT_SET <- function(worker, args) {
     if (is.null(args)) {
       worker$timer <- NULL
     } else {
-      worker$timer <- queuer::time_checker(args, remaining = TRUE)
+      worker$timer <- time_checker(args, remaining = TRUE)
     }
     "OK"
   } else {
@@ -107,7 +107,7 @@ run_message_TIMEOUT_GET <- function(worker) {
       ## through one BLPOP cycle.  So, if a TIMEOUT_GET message is
       ## issued _immediately_ after running a task then there will be
       ## no timer here, but there should be.
-      worker$timer <- queuer::time_checker(worker$timeout, TRUE)
+      worker$timer <- time_checker(worker$timeout, TRUE)
     }
     c(timeout = worker$timeout, remaining = worker$timer())
   }

--- a/R/worker_messages.R
+++ b/R/worker_messages.R
@@ -84,11 +84,7 @@ run_message_RESUME <- function(worker, args) {
 run_message_TIMEOUT_SET <- function(worker, args) {
   if (is.numeric(args) || is.null(args)) {
     worker$timeout <- args
-    if (is.null(args)) {
-      worker$timer <- NULL
-    } else {
-      worker$timer <- time_checker(args, remaining = TRUE)
-    }
+    worker$timer_start()
     "OK"
   } else {
     "INVALID"
@@ -99,17 +95,19 @@ run_message_TIMEOUT_GET <- function(worker) {
   if (is.null(worker$timeout)) {
     c(timeout = Inf, remaining = Inf)
   } else {
+    ## NOTE: This is a slightly odd construction; it arises because
+    ## the timer is not just suspended between tasks; it is removed
+    ## entirely.  So the worker runs a task (deleting the timer),
+    ## and the timer will not be restored until after it makes it
+    ## through one BLPOP cycle.  So, if a TIMEOUT_GET message is
+    ## issued _immediately_ after running a task then there will be
+    ## no timer here.
     if (is.null(worker$timer)) {
-      ## NOTE: This is a slightly odd construction; it arises because
-      ## the timer is not just suspended between tasks; it is removed
-      ## entirely.  So the worker runs a task (deleting the timer),
-      ## and the timer will not be restored until after it makes it
-      ## through one BLPOP cycle.  So, if a TIMEOUT_GET message is
-      ## issued _immediately_ after running a task then there will be
-      ## no timer here, but there should be.
-      worker$timer <- time_checker(worker$timeout, TRUE)
+      remaining <- worker$timeout
+    } else {
+      remaining <- worker$timer()
     }
-    c(timeout = worker$timeout, remaining = worker$timer())
+    c(timeout = worker$timeout, remaining = remaining)
   }
 }
 

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -22,7 +22,7 @@ worker_run_task_rrq <- function(worker, task_id) {
   con <- worker$con
 
   dat <- bin_to_object(con$HGET(keys$task_expr, task_id))
-  e <- context::restore_locals(dat, worker$envir, worker$db)
+  e <- expression_restore_locals(dat, worker$envir, worker$db)
 
   res <- expression_eval_safely(dat$expr, e)
   value <- res$value

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -24,8 +24,7 @@ worker_run_task_rrq <- function(worker, task_id) {
   dat <- bin_to_object(con$HGET(keys$task_expr, task_id))
   e <- context::restore_locals(dat, worker$envir, worker$db)
 
-  cl <- c("rrq_task_error", "try-error")
-  res <- context:::eval_safely(dat$expr, e, cl, 3L)
+  res <- expression_eval_safely(dat$expr, e)
   value <- res$value
 
   task_status <- if (res$success) TASK_COMPLETE else TASK_ERROR

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -42,12 +42,6 @@ worker_run_task_cleanup <- function(worker, task_id, task_status) {
   key_complete <- con$HGET(keys$task_complete, task_id)
   name <- worker$name
 
-  ## TODO: I should enforce a max size policy here.  So if the
-  ## return value is too large (say more than a few kb) we can
-  ## refuse to write it to the db but instead route it through the
-  ## context db.  That policy can be set by the db pretty easily
-  ## actually.
-  ##
   ## TODO: for interrupted tasks, I don't know that we should
   ## write to the key_complete set; at the same time _not_ doing
   ## that requires that we can gracefully (and automatically)

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -1,58 +1,42 @@
 worker_run_task <- function(worker, task_id) {
-  worker_run_task_start(worker, task_id)
-  task_status <- worker_run_task_rrq(worker, task_id)
-  worker_run_task_cleanup(worker, task_id, task_status)
+  dat <- worker_run_task_start(worker, task_id)
+  task <- dat$task
+  e <- expression_restore_locals(task, worker$envir, worker$db)
+  res <- expression_eval_safely(task$expr, e)
+  task_status <- if (res$success) TASK_COMPLETE else TASK_ERROR
+  worker_run_task_cleanup(worker, task_id, task_status, res$value,
+                          dat$key_complete)
 }
 
 
 worker_run_task_start <- function(worker, task_id) {
   keys <- worker$keys
   name <- worker$name
-  worker$log("TASK_START", task_id)
-  worker$con$pipeline(
+  dat <- worker$con$pipeline(
+    worker_log(redis, keys, "TASK_START", "task_id"),
     redis$HSET(keys$worker_status, name,      WORKER_BUSY),
     redis$HSET(keys$worker_task,   name,      task_id),
     redis$HSET(keys$task_worker,   task_id,   name),
-    redis$HSET(keys$task_status,   task_id,   TASK_RUNNING))
+    redis$HSET(keys$task_status,   task_id,   TASK_RUNNING),
+    redis$HGET(keys$task_complete, task_id),
+    redis$HGET(keys$task_expr,     task_id))
+  list(task = bin_to_object(dat[[7]]), key_complete = dat[[6]])
 }
 
 
-worker_run_task_rrq <- function(worker, task_id) {
+worker_run_task_cleanup <- function(worker, task_id, status, value,
+                                    key_complete) {
   keys <- worker$keys
-  con <- worker$con
-
-  dat <- bin_to_object(con$HGET(keys$task_expr, task_id))
-  e <- expression_restore_locals(dat, worker$envir, worker$db)
-
-  res <- expression_eval_safely(dat$expr, e)
-  value <- res$value
-
-  task_status <- if (res$success) TASK_COMPLETE else TASK_ERROR
-  con$pipeline(
-    redis$HSET(keys$task_result, task_id, object_to_bin(value)),
-    redis$HSET(keys$task_status, task_id, task_status))
-
-  task_status
-}
-
-
-worker_run_task_cleanup <- function(worker, task_id, task_status) {
-  con <- worker$con
-  keys <- worker$keys
-  key_complete <- con$HGET(keys$task_complete, task_id)
   name <- worker$name
-
-  ## TODO: for interrupted tasks, I don't know that we should
-  ## write to the key_complete set; at the same time _not_ doing
-  ## that requires that we can gracefully (and automatically)
-  ## handle the restarts.
-  con$pipeline(
-    redis$HSET(keys$task_status,    task_id,  task_status),
+  log_status <- paste0("TASK_", status)
+  worker$con$pipeline(
+    redis$HSET(keys$task_result,    task_id,  object_to_bin(value)),
+    redis$HSET(keys$task_status,    task_id,  status),
     redis$HSET(keys$worker_status,  name,     WORKER_IDLE),
     redis$HDEL(keys$worker_task,    name),
     if (!is.null(key_complete)) {
       redis$RPUSH(key_complete, task_id)
-    })
-
-  worker$log(paste0("TASK_", task_status), task_id)
+    },
+    worker_log(redis, keys, log_status, task_id))
+  invisible()
 }

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/u8e9nulhk7ryo5jd?svg=true)](https://ci.appveyor.com/project/richfitz/rrq-xkvo8)
 [![codecov.io](https://codecov.io/github/mrc-ide/rrq/coverage.svg?branch=master)](https://codecov.io/github/mrc-ide/rrq?branch=master)
 
-Simple Redis queue in R.  This is like the bigger package `rrqueue`, but using `context` for most of the heavy lifting and aiming to be more like the lightweight parallelisation packages out there.
-
-Once this works I'll rework `rrqueue` off of this codebase probably.
+Simple Redis queue in R.
 
 ## Installation
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,6 @@ install:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github mrc-ide/context
-  - travis-tool.sh install_github mrc-ide/queuer
   - travis-tool.sh install_github richfitz/heartbeatr
 
 test_script:

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -22,7 +22,7 @@ skip_if_no_redis <- function() {
 
 wait_status <- function(t, obj, timeout = 2, time_poll = 0.05,
                         status = "PENDING") {
-  times_up <- queuer:::time_checker(timeout)
+  times_up <- time_checker(timeout)
   while (!times_up()) {
     if (all(obj$task_status(t) != status)) {
       return()

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -22,8 +22,8 @@ skip_if_no_redis <- function() {
 
 wait_status <- function(t, obj, timeout = 2, time_poll = 0.05,
                         status = "PENDING") {
-  times_up <- time_checker(timeout)
-  while (!times_up()) {
+  remaining <- time_checker(timeout)
+  while (remaining() > 0) {
     if (all(obj$task_status(t) != status)) {
       return()
     }

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -100,4 +100,3 @@ with_options <- function(opts, code) {
 
 
 options(rrq.progress = FALSE)
-Sys.unsetenv("CONTEXT_CORES")

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -68,7 +68,7 @@ test_rrq <- function(sources = NULL, root = tempfile()) {
 
 test_worker_spawn <- function(obj, ..., timeout = 10) {
   skip_on_cran()
-  worker_spawn(obj, ..., progress = PROGRESS, timeout = timeout)
+  worker_spawn(obj, ..., timeout = timeout)
 }
 
 
@@ -92,6 +92,12 @@ make_counter <- function(start = 0L) {
 }
 
 
-PROGRESS <- FALSE # TODO: phase this one out
-options(queuer.progress_suppress = TRUE)
+with_options <- function(opts, code) {
+  oo <- options(opts)
+  on.exit(options(oo))
+  force(code)
+}
+
+
+options(rrq.progress = FALSE)
 Sys.unsetenv("CONTEXT_CORES")

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -4,7 +4,7 @@ test_that("eval safely - simple case", {
   e <- list2env(list(a = 1, b = 2), parent = baseenv())
   expect_equal(
     expression_eval_safely(quote(a + b), e),
-    list(value = 3, success = TRUE, warnings = character(0)))
+    list(value = 3, success = TRUE))
 })
 
 
@@ -31,12 +31,131 @@ test_that("eval safely - collect warnings", {
     for (i in seq_len(x)) {
       warning(sprintf("This is warning number %d", i))
     }
-    x
+    stop("giving up now")
   }
 
   suppressWarnings(
     res <- expression_eval_safely(f(4), new.env(parent = baseenv())))
-  expect_equal(res$warnings, sprintf("This is warning number %d", 1:4))
-  expect_true(res$success)
-  expect_equal(res$value, 4)
+  expect_equal(res$value$warnings, sprintf("This is warning number %d", 1:4))
+  expect_false(res$success)
+})
+
+
+test_that("store expression", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(1)), e, NULL, db)
+  expect_equal(res, list(expr = quote(sin(1))))
+  expect_equal(db$list(), character(0))
+})
+
+
+test_that("store locals", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(a) + cos(b)), e, NULL, db)
+
+  h <- c(a = db$hash_object(1), b = db$hash_object(2))
+  expect_equal(res$expr, quote(sin(a) + cos(b)))
+  expect_equal(res$objects, h)
+  expect_equal(sort(db$list()), sort(unname(h)))
+  expect_equal(db$mget(h), list(1, 2))
+})
+
+
+test_that("skip analysis", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(a) + cos(b)), e, NULL, db,
+                            analyse = FALSE)
+  expect_equal(res, list(expr = quote(sin(a) + cos(b))))
+  expect_equal(db$list(), character(0))
+})
+
+
+test_that("add variables", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(a) + cos(b)), e, NULL, db,
+                            analyse = FALSE, include = "a")
+
+  h <- db$hash_object(1)
+  expect_equal(res$expr, quote(sin(a) + cos(b)))
+  expect_equal(res$objects, c(a = h))
+  expect_equal(db$list(), h)
+  expect_equal(db$get(h), 1)
+})
+
+
+test_that("exclude variables", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(a) + cos(b)), e, NULL, db,
+                            exclude = "a")
+
+  h <- db$hash_object(2)
+  expect_equal(res$expr, quote(sin(a) + cos(b)))
+  expect_equal(res$objects, c(b = h))
+  expect_equal(db$list(), h)
+  expect_equal(db$get(h), 2)
+})
+
+
+test_that("recognise base variables", {
+  db <- storr::storr_environment()
+  e1 <- list2env(list(a = 1), parent = baseenv())
+  e2 <- list2env(list(b = 2), parent = baseenv())
+  e3 <- new.env(parent = e2)
+
+  res <- expression_prepare(quote(sin(a) + cos(b)), e1, e2, db)
+
+  h <- db$hash_object(1)
+  expect_equal(res$expr, quote(sin(a) + cos(b)))
+  expect_equal(res$objects, c(a = h))
+  expect_equal(db$list(), h)
+  expect_equal(db$get(h), 1)
+
+  expect_equal(expression_prepare(quote(sin(a) + cos(b)), e1, e3, db), res)
+  expect_error(expression_prepare(quote(sin(a) + cos(b)), e1, e1, db),
+               "not all objects found: b")
+})
+
+
+test_that("restore locals", {
+  e <- new.env()
+  db <- storr::storr_environment()
+  h1 <- db$set_by_value(1)
+  h2 <- db$set_by_value(2)
+
+  res <- expression_restore_locals(list(objects = c(a = h1)), e, db)
+  expect_equal(ls(res), "a")
+  expect_equal(res$a, 1)
+  expect_identical(parent.env(res), e)
+})
+
+
+test_that("can store special function values", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  f <- function(a, b) f(a + b)
+  ## Can't compute the hash with db$hash_object because we get a
+  ## different one each time in a local environment due to the local
+  ## environment.
+  res <- expression_prepare(quote(.(a, b)), e, NULL, db,
+                            function_value = f)
+  expect_match(res$function_hash, "^[[:xdigit:]]+$")
+  e2 <- expression_restore_locals(res, emptyenv(), db)
+  expect_equal(sort(names(e2)), sort(c("a", "b", res$function_hash)))
+  expect_equal(e2[[res$function_hash]], f)
+  expect_equal(e2$a, 1)
+  expect_equal(e2$b, 2)
+})
+
+
+test_that("require a call to prepre", {
+  db <- storr::storr_environment()
+  expect_error(expression_prepare(quote(a), emptyenv(), NULL, db),
+               "Expected a call")
+  expect_error(expression_prepare(quote(1), emptyenv(), NULL, db),
+               "Expected a call")
 })

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -1,0 +1,42 @@
+context("expression")
+
+test_that("eval safely - simple case", {
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  expect_equal(
+    expression_eval_safely(quote(a + b), e),
+    list(value = 3, success = TRUE, warnings = character(0)))
+})
+
+
+test_that("eval safely - error", {
+  f1 <- function(x) f2(x)
+  f2 <- function(x) f3(x)
+  f3 <- function(x) f4(x)
+  f4 <- function(x) {
+    stop("some deep error")
+  }
+
+  res <- expression_eval_safely(f1(FALSE), e)
+  expect_false(res$success)
+  expect_is(res$value, "rrq_task_error")
+  expect_is(res$value, "error")
+  expect_equal(res$value$message, "some deep error")
+  expect_is(res$value$trace, "character")
+  expect_match(res$value$trace, "f3(x)", fixed = TRUE, all = FALSE)
+})
+
+
+test_that("eval safely - collect warnings", {
+  f <- function(x) {
+    for (i in seq_len(x)) {
+      warning(sprintf("This is warning number %d", i))
+    }
+    x
+  }
+
+  suppressWarnings(
+    res <- expression_eval_safely(f(4), new.env(parent = baseenv())))
+  expect_equal(res$warnings, sprintf("This is warning number %d", 1:4))
+  expect_true(res$success)
+  expect_equal(res$value, 4)
+})

--- a/tests/testthat/test-message.R
+++ b/tests/testthat/test-message.R
@@ -90,7 +90,10 @@ test_that("TIMEOUT_GET restores a timer", {
   w$step(TRUE)
   res <- obj$message_get_response(id, w$name)[[1]]
   expect_equal(res[["timeout"]], 100)
-  expect_lte(res[["remaining"]], 100)
+  expect_equal(res[["remaining"]], 100)
+  expect_null(w$timer)
+
+  w$step(TRUE)
   expect_is(w$timer, "function")
 })
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -72,14 +72,11 @@ test_that("task warnings are returned", {
 
   r1 <- obj$task_result(t1)
   expect_is(r1, "rrq_task_error")
-  expect_is(r1, "try-error")
-  expect_is(r1$warnings, "list")
+  expect_is(r1$warnings, "character")
   expect_equal(length(r1$warnings), 2)
-  expect_is(r1$warnings[[1]], "simpleWarning")
-  expect_equal(r1$warnings[[1]]$message, "This is warning number 1")
-  expect_equal(r1$warnings[[2]]$message, "This is warning number 2")
+  expect_equal(r1$warnings, sprintf("This is warning number %d", 1:2))
 
-  expect_match(tail(r1$trace, 2)[[1]], "^warning_then_error")
+  expect_match(r1$trace, "^warning_then_error", all = FALSE)
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -34,7 +34,7 @@ test_that("basic use", {
   t <- obj$enqueue(slowdouble(0.1))
   expect_is(t, "character")
   w$step(TRUE)
-  expect_equal(obj$task_wait(t, 2, progress = PROGRESS), 0.2)
+  expect_equal(obj$task_wait(t, 2), 0.2)
   expect_equal(obj$task_result(t), 0.2)
 })
 

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -1,0 +1,21 @@
+context("time")
+
+test_that("time_checker", {
+  t <- time_checker(100, FALSE)
+  expect_false(t())
+  t <- time_checker(100, TRUE)
+  expect_gt(t(), 0)
+
+  t <- time_checker(0, FALSE)
+  Sys.sleep(0.001)
+  expect_true(t())
+  t <- time_checker(0, TRUE)
+  expect_lte(t(), 0)
+})
+
+test_that("time_checker - infinite time", {
+  t <- time_checker(Inf, FALSE)
+  expect_false(t())
+  t <- time_checker(Inf, TRUE)
+  expect_equal(t(), Inf)
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -12,3 +12,87 @@ test_that("time_checker - infinite time", {
   t <- time_checker(Inf)
   expect_equal(t(), Inf)
 })
+
+
+test_that("show_progress", {
+  with_options(list(rrq.progress = TRUE), {
+    expect_true(show_progress(NULL))
+    expect_true(show_progress(TRUE))
+    expect_false(show_progress(FALSE))
+  })
+
+  with_options(list(rrq.progress = FALSE), {
+    expect_false(show_progress(NULL))
+    expect_true(show_progress(TRUE))
+    expect_false(show_progress(FALSE))
+  })
+
+  with_options(list(rrq.progress = NULL), {
+    expect_equal(show_progress(NULL), interactive())
+    expect_true(show_progress(TRUE))
+    expect_false(show_progress(FALSE))
+  })
+})
+
+
+test_that("progress - vector and with timeout", {
+  skip_on_cran() # too dependent on progress internals
+  p <- progress_timeout(10, show = TRUE, label = "things", timeout = 5,
+                        width = 50, force = TRUE)
+  expect_is(p, "function")
+
+  res1 <- evaluate_promise(p(1))
+  expect_equal(res1$result, FALSE)
+  expect_match(res1$messages[[2]],
+               "(-) [>------------]  10% things | giving up in",
+               fixed = TRUE)
+
+  res2 <- evaluate_promise(p(4))
+  expect_equal(res2$result, FALSE)
+  expect_match(res2$messages[[2]],
+               "(\\) [=====>-------]  50% things | giving up in",
+               fixed = TRUE)
+
+  res3 <- evaluate_promise(p(5))
+  expect_match(res3$messages[[2]],
+               "(|) [=============] 100% things | giving up in",
+               fixed = TRUE)
+})
+
+
+test_that("progress - single and infinite", {
+  skip_on_cran() # too dependent on progress internals
+  p <- progress_timeout(1, show = TRUE, label = "things", timeout = Inf,
+                        width = 50, force = TRUE)
+  expect_is(p, "function")
+
+  res1 <- evaluate_promise(p())
+  expect_equal(res1$result, FALSE)
+  expect_match(res1$messages[[2]],
+               "(-) waiting for thing | waited for",
+               fixed = TRUE)
+
+  res2 <- evaluate_promise(p())
+  expect_equal(res2$result, FALSE)
+  expect_match(res2$messages[[2]],
+               "(\\) waiting for thing | waited for",
+               fixed = TRUE)
+})
+
+
+test_that("progress - don't show", {
+  p <- progress_timeout(1, show = FALSE, label = "things", timeout = Inf,
+                        width = 50, force = TRUE)
+  expect_is(p, "function")
+  expect_silent(p())
+  expect_false(p())
+})
+
+
+test_that("progress - timeout", {
+  p <- progress_timeout(1, show = FALSE, label = "things", timeout = 0,
+                        width = 50, force = TRUE)
+  expect_is(p, "function")
+  expect_silent(p())
+  expect_true(p())
+})

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -1,21 +1,14 @@
 context("time")
 
 test_that("time_checker", {
-  t <- time_checker(100, FALSE)
-  expect_false(t())
-  t <- time_checker(100, TRUE)
+  t <- time_checker(100)
   expect_gt(t(), 0)
 
-  t <- time_checker(0, FALSE)
-  Sys.sleep(0.001)
-  expect_true(t())
-  t <- time_checker(0, TRUE)
+  t <- time_checker(0)
   expect_lte(t(), 0)
 })
 
 test_that("time_checker - infinite time", {
-  t <- time_checker(Inf, FALSE)
-  expect_false(t())
-  t <- time_checker(Inf, TRUE)
+  t <- time_checker(Inf)
   expect_equal(t(), Inf)
 })

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -31,8 +31,8 @@ test_that("create short-lived worker", {
   expect_is(log, "data.frame")
   expect_true(nrow(log) >= 1)
 
-  times_up <- time_checker(3)
-  while (!times_up()) {
+  remaining <- time_checker(3)
+  while (remaining() > 0) {
     log <- obj$worker_log_tail(wid, Inf)
     if (nrow(log) >= 2L) {
       break

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -31,7 +31,7 @@ test_that("create short-lived worker", {
   expect_is(log, "data.frame")
   expect_true(nrow(log) >= 1)
 
-  times_up <- queuer:::time_checker(3)
+  times_up <- time_checker(3)
   while (!times_up()) {
     log <- obj$worker_log_tail(wid, Inf)
     if (nrow(log) >= 2L) {

--- a/tests/testthat/test-worker-spawn.R
+++ b/tests/testthat/test-worker-spawn.R
@@ -27,7 +27,7 @@ test_that("failed spawn", {
   expect_is(dat$result, "try-error")
   expect_match(dat$messages, "2 / 2 workers not identified in time",
                all = FALSE, fixed = TRUE)
-  expect_match(dat$messages, "Log files recovered for 2 workers",
+  expect_match(dat$output, "Log files recovered for 2 workers",
                all = FALSE, fixed = TRUE)
   ## This fails occasionally under covr, but I can't reproduce
   ## expect_match(dat$output, "No such file or directory",


### PR DESCRIPTION
This PR removes use of the `context` and `queuer` packages from `rrq`.  Doing this will allow us to do two things:

* submit the package to CRAN without worrying about a long dependency chain
* re-implement the bulk submission (`lapply` - like interface) in a way that fits better with the new environment creation

The bulk of the new code here was directly copied in from `context` / `queuer` with simplifications to remove unused code branches.  The code in `expression.R` will change when we do bulk submission, and includes a couple of options that are not (yet) exposed to `enqueue`. The progress bar bits are all a bit tedious, but nice for interactive use.