### PR TITLE
MRC-601: refactor worker

### DIFF
--- a/R/heartbeat.R
+++ b/R/heartbeat.R
@@ -1,11 +1,11 @@
-heartbeat <- function(con, keys, period) {
+heartbeat <- function(con, keys, period, verbose) {
   if (!is.null(period)) {
     key <- keys$worker_heartbeat
-    worker_log(con, keys, "HEARTBEAT", key)
+    worker_log(con, keys, "HEARTBEAT", key, verbose)
     loadNamespace("heartbeatr")
     config <- con$config()
     ret <- heartbeatr::heartbeat(key, period, config = config)
-    worker_log(con, keys, "HEARTBEAT", "OK")
+    worker_log(con, keys, "HEARTBEAT", "OK", verbose)
     ret
   }
 }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -204,9 +204,10 @@ R6_rrq_controller <- R6::R6Class(
     },
 
     worker_config_save = function(name, time_poll = NULL, timeout = NULL,
-                                  heartbeat_period = NULL, overwrite = TRUE) {
+                                  heartbeat_period = NULL, verbose = NULL,
+                                  overwrite = TRUE) {
       worker_config_save(self$con, self$keys, name, time_poll, timeout,
-                         heartbeat_period, overwrite)
+                         heartbeat_period, verbose, overwrite)
     },
 
     worker_config_list = function() {

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -293,11 +293,12 @@ task_delete <- function(con, keys, task_ids, check = TRUE) {
       stop("Can't delete running tasks")
     }
   }
-  con$HDEL(keys$task_expr,     task_ids)
-  con$HDEL(keys$task_status,   task_ids)
-  con$HDEL(keys$task_result,   task_ids)
-  con$HDEL(keys$task_complete, task_ids)
-  con$HDEL(keys$task_worker,   task_ids)
+  con$pipeline(
+    redis$HDEL(keys$task_expr,     task_ids),
+    redis$HDEL(keys$task_status,   task_ids),
+    redis$HDEL(keys$task_result,   task_ids),
+    redis$HDEL(keys$task_complete, task_ids),
+    redis$HDEL(keys$task_worker,   task_ids))
   invisible()
 }
 

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -11,6 +11,12 @@ assert_character <- function(x, name = deparse(substitute(x))) {
   }
 }
 
+assert_logical <- function(x, name = deparse(substitute(x))) {
+  if (!is.logical(x)) {
+    stop(sprintf("%s must be logical", name), call. = FALSE)
+  }
+}
+
 assert_character_or_null <- function(x, name = deparse(substitute(x))) {
   if (!is.null(x)) {
     assert_character(x, name)
@@ -34,6 +40,11 @@ assert_length <- function(x, n, name = deparse(substitute(x))) {
 assert_scalar_character <- function(x, name = deparse(substitute(x))) {
   assert_scalar(x, name)
   assert_character(x, name)
+}
+
+assert_scalar_logical <- function(x, name = deparse(substitute(x))) {
+  assert_scalar(x, name)
+  assert_logical(x, name)
 }
 
 assert_integer_like <- function(x, name = deparse(substitute(x))) {

--- a/R/worker.R
+++ b/R/worker.R
@@ -315,8 +315,7 @@ worker_catch_interrupt <- function(worker) {
 
     active <- worker$active_task
     if (!is.null(active)) {
-      worker_run_task_cleanup(worker, active$task_id, TASK_INTERRUPTED, NULL,
-                              active$key_complete)
+      worker_run_task_cleanup(worker, TASK_INTERRUPTED, NULL)
     }
 
     ## There are two ways that interrupt happens (ignoring the

--- a/R/worker.R
+++ b/R/worker.R
@@ -249,6 +249,9 @@ worker_step <- function(worker, immediate) {
 
 
 worker_loop <- function(worker, immediate = FALSE) {
+  cache$active_worker <- worker
+  on.exit(cache$active_worker <- NULL)
+
   if (worker$verbose) {
     message(paste0(worker_banner("start"), collapse = "\n"))
     message(paste0(worker$format(), collapse = "\n"))

--- a/R/worker.R
+++ b/R/worker.R
@@ -117,8 +117,8 @@ R6_rrq_worker <- R6::R6Class(
       worker_step(self, immediate)
     },
 
-    loop = function() {
-      worker_loop(self)
+    loop = function(immediate = FALSE) {
+      worker_loop(self, immediate)
     },
 
     run_task = function(task_id) {
@@ -222,8 +222,8 @@ worker_send_signal <- function(con, keys, signal, worker_ids) {
 
 ## One step of a worker life cycle; i.e., the least we can
 ## interestingly do
-worker_step <- function(worker) {
-  task <- worker$poll()
+worker_step <- function(worker, immediate) {
+  task <- worker$poll(immediate)
   keys <- worker$keys
 
   if (!is.null(task)) {

--- a/R/worker_config.R
+++ b/R/worker_config.R
@@ -1,11 +1,12 @@
 worker_config_save <- function(con, keys, name,
                                time_poll = NULL, timeout = NULL,
                                heartbeat_period = NULL,
+                               verbose = NULL,
                                overwrite = TRUE) {
   key <- keys$worker_config
   write <- overwrite || con$HEXISTS(key, name) == 0
   if (write) {
-    config <- worker_config_make(time_poll, timeout, heartbeat_period)
+    config <- worker_config_make(time_poll, timeout, heartbeat_period, verbose)
     con$HSET(key, name, object_to_bin(config))
     invisible(config)
   } else {
@@ -24,7 +25,7 @@ worker_config_read <- function(con, keys, name) {
 
 
 worker_config_make <- function(time_poll = NULL, timeout = NULL,
-                               heartbeat_period = NULL) {
+                               heartbeat_period = NULL, verbose = NULL) {
   if (!is.null(time_poll)) {
     assert_scalar_integer_like(time_poll)
   }
@@ -34,8 +35,15 @@ worker_config_make <- function(time_poll = NULL, timeout = NULL,
   if (!is.null(heartbeat_period)) {
     assert_scalar_integer_like(heartbeat_period)
   }
+  if (!is.null(verbose)) {
+    assert_scalar_logical(verbose)
+  } else {
+    verbose <- TRUE
+  }
+
   config <- list(time_poll = time_poll,
                  timeout = timeout,
-                 heartbeat_period = heartbeat_period)
+                 heartbeat_period = heartbeat_period,
+                 verbose = verbose)
   config[!vlapply(config, is.null)]
 }

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -1,11 +1,9 @@
 worker_run_task <- function(worker, task_id) {
-  dat <- worker_run_task_start(worker, task_id)
-  task <- dat$task
+  dat <- worker_run_task_start(worker, task_id)$task
   e <- expression_restore_locals(task, worker$envir, worker$db)
   res <- expression_eval_safely(task$expr, e)
   task_status <- if (res$success) TASK_COMPLETE else TASK_ERROR
-  worker_run_task_cleanup(worker, task_id, task_status, res$value,
-                          dat$key_complete)
+  worker_run_task_cleanup(worker, task_status, res$value)
 }
 
 
@@ -33,16 +31,15 @@ worker_run_task_start <- function(worker, task_id) {
   list(task = bin_to_object(dat[[7]]), key_complete = key_complete)
 }
 
-## There is a bit of a tension here in passing arond task_id and
-## key_complete and working with active_task which holds that same
-## information.  This is only used here and in the interrupt cleanup,
-## so is easy enough to refactor to tidy up.
-worker_run_task_cleanup <- function(worker, task_id, status, value,
-                                    key_complete) {
+worker_run_task_cleanup <- function(worker, status, value) {
+  task <- worker$active_task
+  task_id <- task$task_id
+  key_complete <- task$key_complete
+
   keys <- worker$keys
   name <- worker$name
   log_status <- paste0("TASK_", status)
-  worker$active_task <- NULL
+
   worker$con$pipeline(
     redis$HSET(keys$task_result,    task_id,  object_to_bin(value)),
     redis$HSET(keys$task_status,    task_id,  status),
@@ -52,5 +49,7 @@ worker_run_task_cleanup <- function(worker, task_id, status, value,
       redis$RPUSH(key_complete, task_id)
     },
     worker_log(redis, keys, log_status, task_id, worker$verbose))
+
+  worker$active_task <- NULL
   invisible()
 }

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -1,5 +1,5 @@
 worker_run_task <- function(worker, task_id) {
-  dat <- worker_run_task_start(worker, task_id)$task
+  task <- worker_run_task_start(worker, task_id)
   e <- expression_restore_locals(task, worker$envir, worker$db)
   res <- expression_eval_safely(task$expr, e)
   task_status <- if (res$success) TASK_COMPLETE else TASK_ERROR
@@ -19,16 +19,13 @@ worker_run_task_start <- function(worker, task_id) {
     redis$HGET(keys$task_complete, task_id),
     redis$HGET(keys$task_expr,     task_id))
 
-  ## Pull this out of the mess above
-  key_complete <- dat[[6]]
-
   ## This holds the bits of worker state we might need to refer to
   ## later for a running task:
-  worker$active_task <- list(task_id = task_id, key_complete = key_complete)
+  worker$active_task <- list(task_id = task_id, key_complete = dat[[6]])
 
   ## And this holds the data used in worker_run_task_to actually run
   ## the task
-  list(task = bin_to_object(dat[[7]]), key_complete = key_complete)
+  bin_to_object(dat[[7]])
 }
 
 worker_run_task_cleanup <- function(worker, status, value) {

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -13,7 +13,7 @@ worker_run_task_start <- function(worker, task_id) {
   keys <- worker$keys
   name <- worker$name
   dat <- worker$con$pipeline(
-    worker_log(redis, keys, "TASK_START", "task_id"),
+    worker_log(redis, keys, "TASK_START", "task_id", worker$verbose),
     redis$HSET(keys$worker_status, name,      WORKER_BUSY),
     redis$HSET(keys$worker_task,   name,      task_id),
     redis$HSET(keys$task_worker,   task_id,   name),
@@ -37,6 +37,6 @@ worker_run_task_cleanup <- function(worker, task_id, status, value,
     if (!is.null(key_complete)) {
       redis$RPUSH(key_complete, task_id)
     },
-    worker_log(redis, keys, log_status, task_id))
+    worker_log(redis, keys, log_status, task_id, worker$verbose))
   invisible()
 }

--- a/R/worker_runner.R
+++ b/R/worker_runner.R
@@ -34,7 +34,8 @@ rrq_worker_from_config <- function(queue_id, worker_config = "localhost",
                     worker_name = worker_name,
                     time_poll = config$time_poll,
                     timeout = config$timeout,
-                    heartbeat_period = config$heartbeat_period)
+                    heartbeat_period = config$heartbeat_period,
+                    verbose = config$verbose)
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,1 @@
+cache <- new.env(parent = emptyenv())

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -6,7 +6,7 @@
 \usage{
 rrq_worker(queue_id, con = redux::hiredis(), key_alive = NULL,
   worker_name = NULL, time_poll = NULL, timeout = NULL,
-  heartbeat_period = NULL)
+  heartbeat_period = NULL, verbose = TRUE)
 }
 \arguments{
 \item{queue_id}{Name of the queue to connect to.  This will be the
@@ -34,6 +34,12 @@ run by all workers.}
 non-NULL then a heartbeat process will be started (using the
 \code{heartbeatr} package) which can be used to build fault
 tolerant queues.}
+
+\item{verbose}{Logical, indicating if the worker should print
+logging output to the screen.  Logging to screen has a small but
+measurable performance cost, and if you will not collect system
+logs from the worker then it is wasted time.  Logging to the
+redis server is always enabled.}
 }
 \description{
 A rrq queue worker.  These are not for interacting with but will

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -29,6 +29,13 @@ test_that("assertions", {
 })
 
 
+test_that("assert_scalar_logical", {
+  expect_error(assert_scalar_logical(1), "must be logical")
+  expect_error(assert_scalar_logical(c(TRUE, FALSE)), "must be a scalar")
+  expect_silent(assert_scalar_logical(TRUE))
+})
+
+
 test_that("version_string", {
   dat <- version_info("R6")
   expect_match(version_string(dat),

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -124,3 +124,13 @@ test_that("rrq_default configuration", {
   expect_null(res2)
   expect_equal(obj$worker_config_read("new"), res1)
 })
+
+
+test_that("verbose is validated", {
+  obj <- test_rrq()
+  expect_error(
+    obj$worker_config_save("quiet", verbose = "no thank you"),
+    "verbose must be logical")
+  obj$worker_config_save("quiet", verbose = FALSE)
+  expect_equal(obj$worker_config_read("quiet"), list(verbose = FALSE))
+})

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -6,7 +6,7 @@ test_that("rrq_default configuration", {
   obj <- test_rrq()
   expect_equal(obj$worker_config_list(), "localhost")
   expect_equal(obj$worker_config_read("localhost"),
-               list(time_poll = 1))
+               list(time_poll = 1, verbose = TRUE))
 })
 
 
@@ -119,7 +119,7 @@ test_that("rrq_default configuration", {
   ## possibly not what is wanted)
   obj <- test_rrq()
   res1 <- obj$worker_config_save("new", timeout = 1, overwrite = FALSE)
-  expect_equal(res1, list(timeout = 1))
+  expect_equal(res1, list(timeout = 1, verbose = TRUE))
   res2 <- obj$worker_config_save("new", timeout = 2, overwrite = FALSE)
   expect_null(res2)
   expect_equal(obj$worker_config_read("new"), res1)


### PR DESCRIPTION
* verbosity should be a property of the worker
* there are more pipelineable commands
* we should not query redis for our own active task

These bookkeeping changes underly mrc-600 and mrc-558 but make them harder to understand if not done separately


