### PR TITLE
MRC-734: Support for cancelling tasks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.1
+Version: 0.2.2
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.2
+
+* Tasks can now be interrupted with `$task_cancel` if running with a heartbeat enabled (mrc-734)
+
 # rrq 0.2.1
 
 * Add support for within-task progress updates, using the `rrq::rrq_task_progress_update` function, which can be called from any task run from `rrq` and queried with `$task_progress` from a `rrq_controller` (mrc-600)

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -13,7 +13,7 @@ worker_run_task_start <- function(worker, task_id) {
   keys <- worker$keys
   name <- worker$name
   dat <- worker$con$pipeline(
-    worker_log(redis, keys, "TASK_START", "task_id", worker$verbose),
+    worker_log(redis, keys, "TASK_START", task_id, worker$verbose),
     redis$HSET(keys$worker_status, name,      WORKER_BUSY),
     redis$HSET(keys$worker_task,   name,      task_id),
     redis$HSET(keys$task_worker,   task_id,   name),

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -30,7 +30,21 @@ wait_status <- function(t, obj, timeout = 2, time_poll = 0.05,
     message(".")
     Sys.sleep(time_poll)
   }
-  stop(sprintf("Did not change status to %s in time", status))
+  stop(sprintf("Did not change status from %s in time", status))
+}
+
+
+wait_worker_status <- function(w, obj, status, timeout = 2,
+                               time_poll = 0.05) {
+  remaining <- time_checker(timeout)
+  while (remaining() > 0) {
+    if (all(obj$worker_status(w) != status)) {
+      return()
+    }
+    message(".")
+    Sys.sleep(time_poll)
+  }
+  stop(sprintf("Did not change status from %s in time", status))
 }
 
 

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -99,4 +99,9 @@ with_options <- function(opts, code) {
 }
 
 
+skip_on_windows <- function() {
+  testthat::skip_on_os("windows")
+}
+
+
 options(rrq.progress = FALSE)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -287,3 +287,22 @@ test_that("worker_send_signal", {
   expect_equal(obj$con$LINDEX(k[[1]], 0), as.character(tools::SIGINT))
   expect_equal(obj$con$LINDEX(k[[2]], 0), as.character(tools::SIGINT))
 })
+
+
+test_that("cancel queued task", {
+  obj <- test_rrq()
+  t <- obj$enqueue(sqrt(1))
+  expect_true(obj$task_cancel(t))
+  expect_equal(obj$task_status(t), setNames(TASK_MISSING, t))
+})
+
+
+test_that("can't cancel completed task", {
+  obj <- test_rrq()
+  w <- test_worker_blocking(obj)
+  t <- obj$enqueue(sqrt(1))
+  w$step(TRUE)
+  expect_error(
+    obj$task_cancel(t),
+    "Task [[:xdigit:]]{32} is not running \\(COMPLETE\\)")
+})

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -189,8 +189,10 @@ test_that("Stop task with interrupt", {
   expect_equal(obj$worker_status(wid), setNames(WORKER_BUSY, wid))
 
   res <- obj$task_cancel(t)
-  expect_equal(res, list(success = TRUE))
+  expect_true(res)
   wait_status(t, obj, status = TASK_RUNNING)
+  wait_worker_status(wid, obj, status = WORKER_BUSY)
+  wait_worker_status(wid, obj, status = WORKER_PAUSED)
 
   expect_equal(obj$task_status(t), setNames(TASK_INTERRUPTED, t))
   expect_equal(obj$worker_status(wid), setNames(WORKER_IDLE, wid))
@@ -199,8 +201,7 @@ test_that("Stop task with interrupt", {
   expect_equal(log$command, c("ALIVE",
                               "TASK_START", "INTERRUPT", "TASK_INTERRUPTED",
                               "MESSAGE", "RESPONSE", "MESSAGE", "RESPONSE"))
-  expect_equal(log$message, c("",
-                              t, "", "",
+  expect_equal(log$message, c("", t, "", t,
                               "PAUSE", "PAUSE", "RESUME", "RESUME"))
 })
 

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -197,6 +197,9 @@ test_that("Stop task with interrupt", {
   expect_equal(obj$task_status(t), setNames(TASK_INTERRUPTED, t))
   expect_equal(obj$worker_status(wid), setNames(WORKER_IDLE, wid))
 
+  ## These checks don't work for covr for unknown reasons, probably to
+  ## do with signal handling.
+  skip_on_covr()
   log <- obj$worker_log_tail(wid, Inf)
   expect_equal(log$command, c("ALIVE",
                               "TASK_START", "INTERRUPT", "TASK_INTERRUPTED",


### PR DESCRIPTION
This PR adds support for cancelling tasks.  It's somewhat delicate due to the potential for race conditions and cancelling the wrong task, and that is explained above the implantation.