### PR TITLE
mrc-1259: Better error message when cancelling non-existant task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.3
+Version: 0.2.4
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.4
+
+* Better error message is given whe non-existant task is cancelled (mrc-1259)
+
 # rrq 0.2.3
 
 * New `$worker_detect_exited` for detecting exited workers when a heartbeat is used (mrc-1231)

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -343,6 +343,10 @@ task_cancel <- function(con, keys, task_id) {
     worker = redis$HGET(keys$task_worker, task_id),
     status = redis$HGET(keys$task_status, task_id))
 
+  if (is.null(dat$status)) {
+    dat$status <- TASK_MISSING
+  }
+
   if (dat$status == TASK_PENDING) {
     task_delete(con, keys, task_id, FALSE)
     dat <- con$pipeline(

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -306,3 +306,12 @@ test_that("can't cancel completed task", {
     obj$task_cancel(t),
     "Task [[:xdigit:]]{32} is not running \\(COMPLETE\\)")
 })
+
+
+test_that("can't cancel nonexistant task", {
+  obj <- test_rrq()
+  id <- ids::random_id()
+  expect_error(
+    obj$task_cancel(id),
+    "Task [[:xdigit:]]{32} is not running \\(MISSING\\)")
+})


### PR DESCRIPTION
This PR prevents an uninformative error while cancelling a non-existant task, replacing it with an informative one. Previously we saw:

```r
obj <- test_rrq()
id <- ids::random_id()
obj$task_cancel(id)
# Error in if (dat$status == TASK_PENDING) { : argument is of length zero
```

Here, we add a status (`TASK_MISSING`) if called with a nonexistant task, and the error will come out as

```
Task abcdef0123456789 is not running (MISSING)"
```

which is consistent with the case when cancelling a complete task

```
Task abcdef0123456789 is not running (COMPLETE)"
```
