### PR TITLE
MRC-1304: Get debug information out of rrq

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.4
+Version: 0.2.5
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.5
+
+* New `$task_data` method for getting underlying task data (mrc-1304)
+
 # rrq 0.2.4
 
 * Better error message is given whe non-existant task is cancelled (mrc-1259)

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -395,9 +395,6 @@ task_data <- function(con, keys, db, task_id) {
   task <- bin_to_object(expr)
   data <- as.list(expression_restore_locals(task, emptyenv(), db))
   task$objects <- data[names(task$objects)]
-  if (!is.null(task$function_hash)) {
-    task$function_value <- data[[task$function_hash]]
-  }
   task
 }
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -327,13 +327,3 @@ test_that("get task info", {
   expect_equal(res$expr, quote(log(a, b)))
   expect_mapequal(res$objects, list(a = 1, b = 2))
 })
-
-
-## This is pretty ugly:
-test_that("get task info with anonymous function", {
-  obj <- test_rrq()
-  grp <- obj$lapply_(1:10, function(x) x + 1, timeout = 0)
-  res <- obj$task_data(grp$task_ids[[1]])
-  expect_equal(res$function_value, function(x) x + 1)
-  expect_equal(res$objects, set_names(list(), character(0)))
-})

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -315,3 +315,25 @@ test_that("can't cancel nonexistant task", {
     obj$task_cancel(id),
     "Task [[:xdigit:]]{32} is not running \\(MISSING\\)")
 })
+
+
+test_that("get task info", {
+  obj <- test_rrq()
+
+  a <- 1
+  b <- 2
+  t <- obj$enqueue(log(a, b))
+  res <- obj$task_data(t)
+  expect_equal(res$expr, quote(log(a, b)))
+  expect_mapequal(res$objects, list(a = 1, b = 2))
+})
+
+
+## This is pretty ugly:
+test_that("get task info with anonymous function", {
+  obj <- test_rrq()
+  grp <- obj$lapply_(1:10, function(x) x + 1, timeout = 0)
+  res <- obj$task_data(grp$task_ids[[1]])
+  expect_equal(res$function_value, function(x) x + 1)
+  expect_equal(res$objects, set_names(list(), character(0)))
+})

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -327,3 +327,12 @@ test_that("get task info", {
   expect_equal(res$expr, quote(log(a, b)))
   expect_mapequal(res$objects, list(a = 1, b = 2))
 })
+
+
+test_that("get task data errors appropriately if task is missing", {
+  obj <- test_rrq()
+  id <- ids::random_id()
+  expect_error(
+    obj$task_data(id),
+    "Task '[[:xdigit:]]+' not found")
+})


### PR DESCRIPTION
This is required to support mrc-1301 in hintr and the interface might change a little. I want to be able to, given a task id, get the expression and local variables for that task.