### PR TITLE
mrc-1667: Fix worker spawn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.5
+Version: 0.2.6
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.6
+
+* Update `worker_spawn` to work with breaking change in docopt (mrc-1667)
+
 # rrq 0.2.5
 
 * New `$task_data` method for getting underlying task data (mrc-1304)

--- a/R/worker_runner.R
+++ b/R/worker_runner.R
@@ -16,10 +16,11 @@ Options:
 --name=NAME      Name of the worker (optional)
 --key-alive=KEY  Key to write to once alive (optional)"
   dat <- docopt::docopt(doc, args)
+  names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
   list(queue_id = dat$queue,
        config = dat$config,
        name = dat$name,
-       key_alive = dat[["key-alive"]])
+       key_alive = dat[["key_alive"]])
 }
 
 

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -260,6 +260,16 @@ test_that("rrq_worker_main_args parse", {
 })
 
 
+test_that("can pass --key-alive", {
+  expect_mapequal(
+    rrq_worker_main_args(c("name", "--key-alive=key")),
+    list(queue_id = "name",
+         config = "localhost",
+         name = NULL,
+         key_alive = "key"))
+})
+
+
 test_that("write worker script", {
   p <- tempfile()
   res <- write_rrq_worker(p)


### PR DESCRIPTION
Looks like this was caused by the docopt breaking change (translating hyphens to underscores). That meant that `--key-alive` was coming through as `key_alive`. We then pass along `dat[["key-alive"]]` which is `NULL` and the worker does not post back to say they're alive, despite clearly being up!

I've taken the same approach as with orderly and doing the to-underscore translation ourselves so that this works with old and new docopt, plus added a test for argument passing.