### PR TITLE
mrc-2068: Support for multiple queues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.10
+Version: 0.2.11
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.11
+
+* Support for multiple queues, with varying priorities. This can be used to create workers that listen to overlapping queues, with "fast" and "slow" queues (mrc-2068)
+
 # rrq 0.2.10
 
 * Gracefully detect multiple killed workers (#22, reported by @MartinHanewald)

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -1,6 +1,6 @@
-rrq_lapply <- function(con, keys, db, x, fun, dots, envir,
+rrq_lapply <- function(con, keys, db, x, fun, dots, envir, queue,
                        timeout, time_poll, progress) {
-  dat <- rrq_lapply_submit(con, keys, db, x, fun, dots, envir)
+  dat <- rrq_lapply_submit(con, keys, db, x, fun, dots, envir, queue)
   if (timeout == 0) {
     return(dat)
   }
@@ -8,10 +8,10 @@ rrq_lapply <- function(con, keys, db, x, fun, dots, envir,
 }
 
 
-rrq_lapply_submit <- function(con, keys, db, x, fun, dots, envir) {
+rrq_lapply_submit <- function(con, keys, db, x, fun, dots, envir, queue) {
   dat <- rrq_lapply_prepare(db, x, fun, dots, envir)
-  key_complete <- rrq_key_task_complete(keys$queue)
-  task_ids <- task_submit_n(con, keys, dat, key_complete)
+  key_complete <- rrq_key_task_complete(keys$queue_id)
+  task_ids <- task_submit_n(con, keys, dat, key_complete, queue)
   ret <- list(task_ids = task_ids, key_complete = key_complete,
               names = names(x))
   class(ret) <- "rrq_bulk"

--- a/R/common.R
+++ b/R/common.R
@@ -23,6 +23,8 @@ WORKER_BUSY <- "BUSY"
 WORKER_EXITED <- "EXITED"
 WORKER_LOST <- "LOST"
 WORKER_PAUSED <- "PAUSED"
+
+QUEUE_DEFAULT <- "default"
 ## nolint end
 
 version_info <- function(package = "rrq") {

--- a/R/keys.R
+++ b/R/keys.R
@@ -26,9 +26,6 @@ rrq_keys_common <- function(queue_id) {
        worker_expect  = sprintf("%s:worker:expect",  queue_id),
        worker_process = sprintf("%s:worker:process", queue_id),
 
-       ## This will be removed
-       queue          = sprintf("%s:queue",          queue_id),
-
        task_expr      = sprintf("%s:task:expr",      queue_id),
        task_status    = sprintf("%s:task:status",    queue_id),
        task_worker    = sprintf("%s:task:worker",    queue_id),

--- a/R/keys.R
+++ b/R/keys.R
@@ -3,14 +3,14 @@
 ## for real RNGs, or with uuids.
 rrq_keys <- function(queue_id, worker_name = NULL) {
   if (is.null(worker_name)) {
-    rrq_keys_queue(queue_id)
+    rrq_keys_common(queue_id)
   } else {
-    c(rrq_keys_queue(queue_id),
+    c(rrq_keys_common(queue_id),
       rrq_keys_worker(queue_id, worker_name))
   }
 }
 
-rrq_keys_queue <- function(queue_id) {
+rrq_keys_common <- function(queue_id) {
   list(queue_id       = queue_id,
 
        controller     = sprintf("%s:controller",     queue_id),
@@ -26,11 +26,13 @@ rrq_keys_queue <- function(queue_id) {
        worker_expect  = sprintf("%s:worker:expect",  queue_id),
        worker_process = sprintf("%s:worker:process", queue_id),
 
+       ## This will be removed
        queue          = sprintf("%s:queue",          queue_id),
 
        task_expr      = sprintf("%s:task:expr",      queue_id),
        task_status    = sprintf("%s:task:status",    queue_id),
        task_worker    = sprintf("%s:task:worker",    queue_id),
+       task_queue     = sprintf("%s:task:queue",     queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
        task_complete  = sprintf("%s:task:complete",  queue_id))
@@ -47,14 +49,21 @@ rrq_keys_worker <- function(queue, worker) {
 rrq_key_worker_message <- function(queue, worker) {
   sprintf("%s:worker:%s:message", queue, worker)
 }
+
 rrq_key_worker_response <- function(queue, worker) {
   sprintf("%s:worker:%s:response", queue, worker)
 }
+
 rrq_key_worker_log <- function(queue, worker) {
   sprintf("%s:worker:%s:log", queue, worker)
 }
+
 rrq_key_worker_heartbeat <- function(queue, worker) {
   sprintf("%s:worker:%s:heartbeat", queue, worker)
+}
+
+rrq_key_queue <- function(queue, name) {
+  sprintf("%s:queue:%s", queue, name %||% QUEUE_DEFAULT)
 }
 
 ## Randomly generated keys:

--- a/R/worker.R
+++ b/R/worker.R
@@ -312,7 +312,7 @@ worker_catch_interrupt <- function(worker) {
   force(worker)
 
   queue_type <- set_names(
-    c("message", "queue"),
+    c("message", rep("queue", length(worker$queue))),
     c(worker$keys$worker_message, worker$queue))
 
   function(e) {

--- a/R/worker.R
+++ b/R/worker.R
@@ -33,13 +33,16 @@
 ##'   logs from the worker then it is wasted time.  Logging to the
 ##'   redis server is always enabled.
 ##'
+##' @param queue Queues to listen on, listed in decreasing order of
+##'   priority. If not given, we listen on the "default" queue.
+##'
 ##' @export
 rrq_worker <- function(queue_id, con = redux::hiredis(), key_alive = NULL,
-                       worker_name = NULL, time_poll = NULL,
-                       timeout = NULL,
+                       worker_name = NULL, queue = NULL,
+                       time_poll = NULL, timeout = NULL,
                        heartbeat_period = NULL, verbose = TRUE) {
-  w <- rrq_worker_$new(con, queue_id, key_alive, worker_name, time_poll,
-                       timeout, heartbeat_period, verbose)
+  w <- rrq_worker_$new(con, queue_id, key_alive, worker_name, queue,
+                       time_poll, timeout, heartbeat_period, verbose)
   w$loop()
   invisible()
 }
@@ -52,6 +55,7 @@ rrq_worker_ <- R6::R6Class(
     name = NULL,
     envir = NULL,
     keys = NULL,
+    queue = NULL,
     con = NULL,
     db = NULL,
     paused = FALSE,
@@ -66,7 +70,7 @@ rrq_worker_ <- R6::R6Class(
     active_task = NULL,
 
     initialize = function(con, queue_id, key_alive = NULL, worker_name = NULL,
-                          time_poll = NULL, timeout = NULL,
+                          queue = NULL, time_poll = NULL, timeout = NULL,
                           heartbeat_period = NULL, verbose = NULL) {
       assert_is(con, "redis_api")
 
@@ -74,6 +78,10 @@ rrq_worker_ <- R6::R6Class(
       self$name <- worker_name %||% ids::adjective_animal()
       self$keys <- rrq_keys(queue_id, self$name)
       self$verbose <- verbose
+
+      queue <- worker_queue(queue)
+      self$queue <- rrq_key_queue(queue_id, queue)
+      self$log("QUEUE", queue)
 
       if (self$con$SISMEMBER(self$keys$worker_name, self$name) == 1L) {
         stop("Looks like this worker exists already...")
@@ -110,7 +118,7 @@ rrq_worker_ <- R6::R6Class(
       if (self$paused) {
         keys <- keys$worker_message
       } else {
-        keys <- c(keys$worker_message, keys$queue)
+        keys <- c(keys$worker_message, self$queue)
       }
       self$loop_task <- blpop(self$con, keys, self$time_poll, immediate)
     },
@@ -166,6 +174,7 @@ worker_info_collect <- function(worker) {
               running = sys$running,
               hostname = hostname(),
               username = username(),
+              queue = worker$queue,
               wd = getwd(),
               pid = process_id(),
               redis_host = redis_config$host,
@@ -304,8 +313,7 @@ worker_catch_interrupt <- function(worker) {
 
   queue_type <- set_names(
     c("message", "queue"),
-    c(worker$keys$worker_message, worker$keys$queue))
-
+    c(worker$keys$worker_message, worker$queue))
 
   function(e) {
     ## NOTE: this won't recursively catch interrupts.  Especially
@@ -379,4 +387,17 @@ worker_log <- function(con, keys, label, value, verbose) {
     message(res$screen)
   }
   con$RPUSH(keys$worker_log, res$redis)
+}
+
+
+worker_queue <- function(queue) {
+  if (is.null(queue)) {
+    queue <- QUEUE_DEFAULT
+  } else {
+    assert_character(queue)
+    if (!(QUEUE_DEFAULT %in% queue)) {
+      queue <- c(queue, QUEUE_DEFAULT)
+    }
+  }
+  queue
 }

--- a/R/worker_config.R
+++ b/R/worker_config.R
@@ -1,12 +1,14 @@
 worker_config_save <- function(con, keys, name,
                                time_poll = NULL, timeout = NULL,
+                               queue = NULL,
                                heartbeat_period = NULL,
                                verbose = NULL,
                                overwrite = TRUE) {
   key <- keys$worker_config
   write <- overwrite || con$HEXISTS(key, name) == 0
   if (write) {
-    config <- worker_config_make(time_poll, timeout, heartbeat_period, verbose)
+    config <- worker_config_make(time_poll, timeout, queue, heartbeat_period,
+                                 verbose)
     con$HSET(key, name, object_to_bin(config))
     invisible(config)
   } else {
@@ -24,13 +26,16 @@ worker_config_read <- function(con, keys, name) {
 }
 
 
-worker_config_make <- function(time_poll = NULL, timeout = NULL,
+worker_config_make <- function(time_poll = NULL, timeout = NULL, queue = NULL,
                                heartbeat_period = NULL, verbose = NULL) {
   if (!is.null(time_poll)) {
     assert_scalar_integer_like(time_poll)
   }
   if (!(is.null(timeout) || identical(timeout, Inf))) {
     assert_scalar_integer_like(timeout)
+  }
+  if (!is.null(queue)) {
+    assert_character(queue)
   }
   if (!is.null(heartbeat_period)) {
     assert_scalar_integer_like(heartbeat_period)
@@ -43,6 +48,7 @@ worker_config_make <- function(time_poll = NULL, timeout = NULL,
 
   config <- list(time_poll = time_poll,
                  timeout = timeout,
+                 queue = queue,
                  heartbeat_period = heartbeat_period,
                  verbose = verbose)
   config[!vlapply(config, is.null)]

--- a/R/worker_runner.R
+++ b/R/worker_runner.R
@@ -9,7 +9,7 @@ rrq_worker_main <- function(args = commandArgs(TRUE)) {
 
 rrq_worker_main_args <- function(args) {
   doc <- "Usage:
-  rrq_worker [options] <queue>
+  rrq_worker [options] <id>
 
 Options:
 --config=NAME    Name of a worker configuration [default: localhost]
@@ -17,7 +17,7 @@ Options:
 --key-alive=KEY  Key to write to once alive (optional)"
   dat <- docopt::docopt(doc, args)
   names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
-  list(queue_id = dat$queue,
+  list(queue_id = dat$id,
        config = dat$config,
        name = dat$name,
        key_alive = dat[["key_alive"]])
@@ -33,6 +33,7 @@ rrq_worker_from_config <- function(queue_id, worker_config = "localhost",
   rrq_worker_$new(con, queue_id,
                   key_alive = key_alive,
                   worker_name = worker_name,
+                  queue = config$queue,
                   time_poll = config$time_poll,
                   timeout = config$timeout,
                   heartbeat_period = config$heartbeat_period,

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -260,7 +260,12 @@ message to all workers to update their environment.}
 \subsection{Method \code{enqueue()}}{
 Queue an expression
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue(expr, envir = parent.frame(), key_complete = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue(
+  expr,
+  envir = parent.frame(),
+  key_complete = NULL,
+  queue = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -276,6 +281,12 @@ the value of \code{a} to the worker along with the expression.}
 \item{\code{key_complete}}{The name of a Redis key to write to once the
 task is complete. You can use this with \verb{$task_wait} to efficiently
 wait for the task to complete (i.e., without using a busy loop).}
+
+\item{\code{queue}}{The queue to add the task to; if not specified the
+"default" queue (which all workers listen to) will be
+used. If you have configured workers to listen to more than
+one queue you can specify that here. Be warned that if you
+push jobs onto a queue with no worker, it will queue forever.}
 }
 \if{html}{\out{</div>}}
 }
@@ -286,7 +297,12 @@ wait for the task to complete (i.e., without using a busy loop).}
 \subsection{Method \code{enqueue_()}}{
 Queue an expression
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_(expr, envir = parent.frame(), key_complete = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_(
+  expr,
+  envir = parent.frame(),
+  key_complete = NULL,
+  queue = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -305,6 +321,12 @@ the value of \code{a} to the worker along with the expression.}
 task is complete. You can use this in conjunction with something
 like \code{BLPOP} to wait until a task is complete without a busy (sleep)
 loop.}
+
+\item{\code{queue}}{The queue to add the task to; if not specified the
+"default" queue (which all workers listen to) will be
+used. If you have configured workers to listen to more than
+one queue you can specify that here. Be warned that if you
+push jobs onto a queue with no worker, it will queue forever.}
 }
 \if{html}{\out{</div>}}
 }
@@ -322,6 +344,7 @@ equivalent to using \verb{$enqueue()} over each element in the list.
   ...,
   dots = NULL,
   envir = parent.frame(),
+  queue = NULL,
   timeout = Inf,
   time_poll = NULL,
   progress = NULL
@@ -342,6 +365,9 @@ as a list of additional arguments. This may be easier to program
 against.}
 
 \item{\code{envir}}{The environment to use to try and find the function}
+
+\item{\code{queue}}{The queue to add the tasks to (see \verb{$enqueue} for
+details).}
 
 \item{\code{timeout}}{Optional timeout, in seconds, after which an
 error will be thrown if the task has not completed.}
@@ -373,6 +399,7 @@ be copied over rather than using their names if possible.
   ...,
   dots = NULL,
   envir = parent.frame(),
+  queue = NULL,
   timeout = Inf,
   time_poll = NULL,
   progress = NULL
@@ -393,6 +420,9 @@ as a list of additional arguments. This may be easier to program
 against.}
 
 \item{\code{envir}}{The environment to use to try and find the function}
+
+\item{\code{queue}}{The queue to add the tasks to (see \verb{$enqueue} for
+details).}
 
 \item{\code{timeout}}{Optional timeout, in seconds, after which an
 error will be thrown if the task has not completed. If a
@@ -515,7 +545,7 @@ all task ids known to this rrq controller is used.}
 \subsection{Method \code{task_position()}}{
 Find the position of one or more tasks in the queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_position(task_ids, missing = 0L)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_position(task_ids, missing = 0L, queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -527,6 +557,9 @@ Find the position of one or more tasks in the queue.
 A task will take value \code{missing} if it is running, complete,
 errored etc and a positive integer if it is in the queue,
 indicating its position (with 1) being the next task to run.}
+
+\item{\code{queue}}{The name of the queue to query (defaults to the
+"default" queue).}
 }
 \if{html}{\out{</div>}}
 }
@@ -736,9 +769,17 @@ Fetch internal data about a task from Redis
 Returns the number of tasks in the queue (waiting for
 an available worker).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_length()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_length(queue = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{queue}}{The name of the queue to query (defaults to the
+"default" queue).}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-queue_list"></a>}}
@@ -746,9 +787,17 @@ an available worker).
 \subsection{Method \code{queue_list()}}{
 Returns the keys in the task queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_list(queue = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{queue}}{The name of the queue to query (defaults to the
+"default" queue).}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-queue_remove"></a>}}
@@ -756,13 +805,16 @@ Returns the keys in the task queue.
 \subsection{Method \code{queue_remove()}}{
 Remove task ids from a queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_remove(task_ids)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_remove(task_ids, queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{task_ids}}{Task ids to remove}
+
+\item{\code{queue}}{The name of the queue to query (defaults to the
+"default" queue).}
 }
 \if{html}{\out{</div>}}
 }
@@ -1000,6 +1052,7 @@ correspond to arguments to \link{rrq_worker}.
   name,
   time_poll = NULL,
   timeout = NULL,
+  queue = NULL,
   heartbeat_period = NULL,
   verbose = NULL,
   overwrite = TRUE
@@ -1020,6 +1073,13 @@ uses, but shorter values are used for debugging.}
 (roughly) equivalent to issuing a \code{TIMEOUT_SET} message
 after initialising the worker, except that it's guaranteed to be
 run by all workers.}
+
+\item{\code{queue}}{Optional character vector of queues to listen on
+for jobs. There is a default queue which is always listened
+on (called 'default'). You can specify additional names here
+and jobs put onto these queues with \verb{$enqueue()} will have
+\emph{higher} priority than the default. You can explicitly list
+the "default" queue (e.g., \code{queue = c("high", "default", "low")}) to set the position of the default queue.}
 
 \item{\code{heartbeat_period}}{Optional period for the heartbeat.  If
 non-NULL then a heartbeat process will be started (using the

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -9,6 +9,7 @@ rrq_worker(
   con = redux::hiredis(),
   key_alive = NULL,
   worker_name = NULL,
+  queue = NULL,
   time_poll = NULL,
   timeout = NULL,
   heartbeat_period = NULL,
@@ -26,6 +27,9 @@ worker is alive.}
 
 \item{worker_name}{Optional worker name.  If omitted, a random
 name will be created.}
+
+\item{queue}{Queues to listen on, listed in decreasing order of
+priority. If not given, we listen on the "default" queue.}
 
 \item{time_poll}{Poll time.  Longer values here will reduce the
 impact on the database but make workers less responsive to being

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -367,8 +367,6 @@ test_that("a worker will pick up tasks from the priority queue", {
 
 test_that("Query jobs in different queues", {
   obj <- test_rrq("myfuns.R")
-  # obj$worker_config_save("localhost", queue = c("a", "b"))
-  # w <- test_worker_blocking(obj)
 
   t1 <- obj$enqueue(sin(1), queue = "a")
   t2 <- obj$enqueue(sin(2), queue = "a")

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -363,3 +363,29 @@ test_that("a worker will pick up tasks from the priority queue", {
   expect_equal(unname(obj$task_status(c(t1, t2, t3))),
                c("COMPLETE", "COMPLETE", "COMPLETE"))
 })
+
+
+test_that("Query jobs in different queues", {
+  obj <- test_rrq("myfuns.R")
+  # obj$worker_config_save("localhost", queue = c("a", "b"))
+  # w <- test_worker_blocking(obj)
+
+  t1 <- obj$enqueue(sin(1), queue = "a")
+  t2 <- obj$enqueue(sin(2), queue = "a")
+  t3 <- obj$enqueue(sin(3), queue = "a")
+
+  expect_equal(unname(obj$task_status(c(t1, t2, t3))),
+               rep("PENDING", 3))
+  expect_equal(obj$queue_list(), character(0))
+  expect_equal(obj$queue_list("a"), c(t1, t2, t3))
+
+  expect_equal(obj$task_position(t1, queue = "a"), 1)
+  expect_equal(obj$task_position(t2, queue = "a"), 2)
+
+  expect_true(obj$queue_remove(t1, queue = "a"))
+  expect_false(obj$queue_remove(t1, queue = "a"))
+
+  expect_equal(obj$task_position(t2, queue = "a"), 1)
+  expect_equal(obj$queue_length("a"), 2)
+  expect_equal(obj$queue_list("a"), c(t2, t3))
+})

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -33,6 +33,8 @@ test_that("interrupt stuck worker (local)", {
   skip_on_os("windows")
   ## This fails on covr with the worker disappearing
   skip_on_covr()
+  ## Fails on CI too, at least for ubuntu/R-devel; mrc-2094
+  skip_on_ci()
 
   obj <- test_rrq("myfuns.R")
 


### PR DESCRIPTION
Basic support for multiple queues within an rrq object. When workers are created a vector of queues (indicated by names) can be specified - they listen to these in descending order.

This is inadequately tested at the moment:

* tests for the affected query methods with multiple jobs on multiple queues
* good tests for the deletion, which is bad enough as it is