### PR TITLE
Add function to queue to list tasks in front of a particular task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.11
+Version: 0.2.12
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.12
+
+* Add `task_preceeding` function to controller to list tasks in front of a particular task in the queue (vimc-4502)
+
 # rrq 0.2.11
 
 * Support for multiple queues, with varying priorities. This can be used to create workers that listen to overlapping queues, with "fast" and "slow" queues (mrc-2068)

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -408,20 +408,16 @@ rrq_controller_ <- R6::R6Class(
     },
 
     ##' @description List the tasks in front of `task_id` in the queue.
-    ##'   If the task is missing from the queue this will return `missing`. If
+    ##'   If the task is missing from the queue this will return NULL. If
     ##'   the task is next in the queue this will return an empty character
     ##'   vector.
     ##'
     ##' @param task_id Task to find the position for.
     ##'
-    ##' @param missing Value to return if the task is not found in the queue.
-    ##'   A task will take value `missing` if it is running, complete,
-    ##'   errored etc.
-    ##'
     ##' @param queue The name of the queue to query (defaults to the
     ##'   "default" queue).
-    task_preceeding = function(task_id, missing = NA_character_, queue = NULL) {
-      task_preceeding(self$con, self$keys, task_id, missing, queue)
+    task_preceeding = function(task_id, queue = NULL) {
+      task_preceeding(self$con, self$keys, task_id, queue)
     },
 
     ##' @description Get the result for a single task (see `$tasks_result`
@@ -921,12 +917,12 @@ task_position <- function(con, keys, task_ids, missing, queue) {
   match(task_ids, queue_contents, missing)
 }
 
-task_preceeding <- function(con, keys, task_id, missing, queue) {
+task_preceeding <- function(con, keys, task_id, queue) {
   key_queue <- rrq_key_queue(keys$queue_id, queue)
   queue_contents <- vcapply(con$LRANGE(key_queue, 0, -1L), identity)
   task_position <- match(task_id, queue_contents)
   if (is.na(task_position)) {
-    return(missing)
+    return(NULL)
   }
   queue_contents[seq_len(task_position - 1)]
 }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -406,6 +406,23 @@ rrq_controller_ <- R6::R6Class(
     task_position = function(task_ids, missing = 0L, queue = NULL) {
       task_position(self$con, self$keys, task_ids, missing, queue)
     },
+    
+    ##' @description List the tasks in front of `task_id` in the queue.
+    ##'   If the task is missing from the queue this will return `missing`. If
+    ##'   the task is next in the queue this will return an empty character
+    ##'   vector.
+    ##'
+    ##' @param task_id Task to find the position for.
+    ##' 
+    ##' @param missing Value to return if the task is not found in the queue.
+    ##'   A task will take value `missing` if it is running, complete,
+    ##'   errored etc.
+    ##'
+    ##' @param queue The name of the queue to query (defaults to the
+    ##'   "default" queue).
+    task_preceeding = function(task_id, missing = NA_character_, queue = NULL) {
+      task_preceeding(self$con, self$keys, task_id, missing, queue)
+    },
 
     ##' @description Get the result for a single task (see `$tasks_result`
     ##'   for a method for efficiently getting multiple results at once).
@@ -902,6 +919,16 @@ task_position <- function(con, keys, task_ids, missing, queue) {
   key_queue <- rrq_key_queue(keys$queue_id, queue)
   queue_contents <- vcapply(con$LRANGE(key_queue, 0, -1L), identity)
   match(task_ids, queue_contents, missing)
+}
+
+task_preceeding <- function(con, keys, task_id, missing, queue) {
+  key_queue <- rrq_key_queue(keys$queue_id, queue)
+  queue_contents <- vcapply(con$LRANGE(key_queue, 0, -1L), identity)
+  task_position <- match(task_id, queue_contents)
+  if (is.na(task_position)) {
+    return(missing)
+  }
+  queue_contents[seq_len(task_position - 1)]
 }
 
 task_submit <- function(con, keys, dat, key_complete, queue) {

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -406,14 +406,14 @@ rrq_controller_ <- R6::R6Class(
     task_position = function(task_ids, missing = 0L, queue = NULL) {
       task_position(self$con, self$keys, task_ids, missing, queue)
     },
-    
+
     ##' @description List the tasks in front of `task_id` in the queue.
     ##'   If the task is missing from the queue this will return `missing`. If
     ##'   the task is next in the queue this will return an empty character
     ##'   vector.
     ##'
     ##' @param task_id Task to find the position for.
-    ##' 
+    ##'
     ##' @param missing Value to return if the task is not found in the queue.
     ##'   A task will take value `missing` if it is running, complete,
     ##'   errored etc.

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -143,6 +143,7 @@ ans <- obj$lapply_(1:10, quote(log), base = quote(b))
 \item \href{#method-task_progress}{\code{rrq_controller_$task_progress()}}
 \item \href{#method-task_overview}{\code{rrq_controller_$task_overview()}}
 \item \href{#method-task_position}{\code{rrq_controller_$task_position()}}
+\item \href{#method-task_preceeding}{\code{rrq_controller_$task_preceeding()}}
 \item \href{#method-task_result}{\code{rrq_controller_$task_result()}}
 \item \href{#method-tasks_result}{\code{rrq_controller_$tasks_result()}}
 \item \href{#method-task_wait}{\code{rrq_controller_$task_wait()}}
@@ -557,6 +558,29 @@ Find the position of one or more tasks in the queue.
 A task will take value \code{missing} if it is running, complete,
 errored etc and a positive integer if it is in the queue,
 indicating its position (with 1) being the next task to run.}
+
+\item{\code{queue}}{The name of the queue to query (defaults to the
+"default" queue).}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-task_preceeding"></a>}}
+\if{latex}{\out{\hypertarget{method-task_preceeding}{}}}
+\subsection{Method \code{task_preceeding()}}{
+List the tasks in front of \code{task_id} in the queue.
+If the task is missing from the queue this will return NULL. If
+the task is next in the queue this will return an empty character
+vector.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_preceeding(task_id, queue = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{task_id}}{Task to find the position for.}
 
 \item{\code{queue}}{The name of the queue to query (defaults to the
 "default" queue).}

--- a/rrq.Rproj
+++ b/rrq.Rproj
@@ -13,6 +13,7 @@ RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -105,12 +105,24 @@ test_that("task_preceeding", {
   expect_equal(obj$task_preceeding(t1), character(0))
   expect_equal(obj$task_preceeding(t2), t1)
   expect_equal(obj$task_preceeding(t3), c(t1, t2))
-  expect_equal(obj$task_preceeding("not a real task"), NA_character_)
-  expect_equal(obj$task_preceeding("not a real task", "missing"), "missing")
-
+  expect_null(obj$task_preceeding("not a real task"))
+  
   wid <- test_worker_spawn(obj)
   obj$task_wait(t3)
-  expect_equal(obj$task_preceeding(t3), NA_character_)
+  expect_null(obj$task_preceeding(t3))
+})
+
+
+test_that("task_position and task_preceeding are consistent", {
+  obj <- test_rrq("myfuns.R")
+  
+  t1 <- obj$enqueue(sin(1))
+  t2 <- obj$enqueue(sin(1))
+  t3 <- obj$enqueue(sin(1))
+  
+  expect_equal(length(obj$task_preceeding(t1)), obj$task_position(t1) - 1)
+  expect_equal(length(obj$task_preceeding(t2)), obj$task_position(t2) - 1)
+  expect_equal(length(obj$task_preceeding(t3)), obj$task_position(t3) - 1)
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -106,7 +106,7 @@ test_that("task_preceeding", {
   expect_equal(obj$task_preceeding(t2), t1)
   expect_equal(obj$task_preceeding(t3), c(t1, t2))
   expect_null(obj$task_preceeding("not a real task"))
-  
+
   wid <- test_worker_spawn(obj)
   obj$task_wait(t3)
   expect_null(obj$task_preceeding(t3))
@@ -115,11 +115,11 @@ test_that("task_preceeding", {
 
 test_that("task_position and task_preceeding are consistent", {
   obj <- test_rrq("myfuns.R")
-  
+
   t1 <- obj$enqueue(sin(1))
   t2 <- obj$enqueue(sin(1))
   t3 <- obj$enqueue(sin(1))
-  
+
   expect_equal(length(obj$task_preceeding(t1)), obj$task_position(t1) - 1)
   expect_equal(length(obj$task_preceeding(t2)), obj$task_position(t2) - 1)
   expect_equal(length(obj$task_preceeding(t3)), obj$task_position(t3) - 1)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -95,6 +95,24 @@ test_that("task_position", {
                c(1L, NA_integer_))
 })
 
+test_that("task_preceeding", {
+  obj <- test_rrq("myfuns.R")
+  
+  t1 <- obj$enqueue(sin(1))
+  t2 <- obj$enqueue(sin(1))
+  t3 <- obj$enqueue(sin(1))
+  
+  expect_equal(obj$task_preceeding(t1), character(0))
+  expect_equal(obj$task_preceeding(t2), t1)
+  expect_equal(obj$task_preceeding(t3), c(t1, t2))
+  expect_equal(obj$task_preceeding("not a real task"), NA_character_)
+  expect_equal(obj$task_preceeding("not a real task", "missing"), "missing")
+  
+  wid <- test_worker_spawn(obj)
+  obj$task_wait(t3)
+  expect_equal(obj$task_preceeding(t3), NA_character_)
+})
+
 
 test_that("task_overview", {
   obj <- test_rrq("myfuns.R")

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -97,17 +97,17 @@ test_that("task_position", {
 
 test_that("task_preceeding", {
   obj <- test_rrq("myfuns.R")
-  
+
   t1 <- obj$enqueue(sin(1))
   t2 <- obj$enqueue(sin(1))
   t3 <- obj$enqueue(sin(1))
-  
+
   expect_equal(obj$task_preceeding(t1), character(0))
   expect_equal(obj$task_preceeding(t2), t1)
   expect_equal(obj$task_preceeding(t3), c(t1, t2))
   expect_equal(obj$task_preceeding("not a real task"), NA_character_)
   expect_equal(obj$task_preceeding("not a real task", "missing"), "missing")
-  
+
   wid <- test_worker_spawn(obj)
   obj$task_wait(t3)
   expect_equal(obj$task_preceeding(t3), NA_character_)


### PR DESCRIPTION
This is info we want to return in orderly.server refactor https://github.com/vimc/orderly.server/pull/35 but I thought would be generally useful. 

Thoughts on function name? I'm trying to follow pattern of naming on the controller but couldn't think of an amazing name for this. `task_preceeding_tasks`? `queue_preceeding_tasks` something like this maybe better? `queued_tasks`?