### PR TITLE
mrc-2068: Add support for sending to external processes

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -40,7 +40,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        if: false
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -40,6 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
+        if: false
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.12
+Version: 0.2.13
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.
@@ -15,6 +15,7 @@ Imports:
     progress,
     redux (>= 1.0.0)
 Suggests:
+    callr,
     heartbeatr,
     storr,
     testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.2.13
+
+* Run tasks in a separate process (with some overhead) with new argument `separate_process = TRUE` to `$enqueue()`. Use this to ensure isolation between tasks (mrc-2068)
+
 # rrq 0.2.12
 
 * Add `task_preceeding` function to controller to list tasks in front of a particular task in the queue (vimc-4502)

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -1,6 +1,7 @@
 rrq_lapply <- function(con, keys, db, x, fun, dots, envir, queue,
-                       timeout, time_poll, progress) {
-  dat <- rrq_lapply_submit(con, keys, db, x, fun, dots, envir, queue)
+                       separate_process, timeout, time_poll, progress) {
+  dat <- rrq_lapply_submit(con, keys, db, x, fun, dots, envir, queue,
+                           separate_process)
   if (timeout == 0) {
     return(dat)
   }
@@ -8,10 +9,12 @@ rrq_lapply <- function(con, keys, db, x, fun, dots, envir, queue,
 }
 
 
-rrq_lapply_submit <- function(con, keys, db, x, fun, dots, envir, queue) {
+rrq_lapply_submit <- function(con, keys, db, x, fun, dots, envir, queue,
+                              separate_process) {
   dat <- rrq_lapply_prepare(db, x, fun, dots, envir)
   key_complete <- rrq_key_task_complete(keys$queue_id)
-  task_ids <- task_submit_n(con, keys, dat, key_complete, queue)
+  task_ids <- task_submit_n(con, keys, dat, key_complete, queue,
+                            separate_process)
   ret <- list(task_ids = task_ids, key_complete = key_complete,
               names = names(x))
   class(ret) <- "rrq_bulk"

--- a/R/keys.R
+++ b/R/keys.R
@@ -30,6 +30,7 @@ rrq_keys_common <- function(queue_id) {
        task_status    = sprintf("%s:task:status",    queue_id),
        task_worker    = sprintf("%s:task:worker",    queue_id),
        task_queue     = sprintf("%s:task:queue",     queue_id),
+       task_local     = sprintf("%s:task:local",     queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
        task_complete  = sprintf("%s:task:complete",  queue_id))

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -265,7 +265,8 @@ Queue an expression
   expr,
   envir = parent.frame(),
   key_complete = NULL,
-  queue = NULL
+  queue = NULL,
+  separate_process = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -288,6 +289,14 @@ wait for the task to complete (i.e., without using a busy loop).}
 used. If you have configured workers to listen to more than
 one queue you can specify that here. Be warned that if you
 push jobs onto a queue with no worker, it will queue forever.}
+
+\item{\code{separate_process}}{Logical, indicating if the task should be
+run in a separate process on the worker. If \code{TRUE}, then the
+worker runs the task in a separate process using the \code{callr}
+package. This means that the worker environment is completely
+clean, subsequent runs are not affected by preceeding ones.
+The downside of this approach is a considerable overhead in
+starting the extenal process and transferring data back.}
 }
 \if{html}{\out{</div>}}
 }
@@ -302,7 +311,8 @@ Queue an expression
   expr,
   envir = parent.frame(),
   key_complete = NULL,
-  queue = NULL
+  queue = NULL,
+  separate_process = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -328,6 +338,10 @@ loop.}
 used. If you have configured workers to listen to more than
 one queue you can specify that here. Be warned that if you
 push jobs onto a queue with no worker, it will queue forever.}
+
+\item{\code{separate_process}}{Logical, indicating if the task should be
+run in a separate process on the worker (see \verb{$enqueue} for
+details).}
 }
 \if{html}{\out{</div>}}
 }
@@ -346,6 +360,7 @@ equivalent to using \verb{$enqueue()} over each element in the list.
   dots = NULL,
   envir = parent.frame(),
   queue = NULL,
+  separate_process = FALSE,
   timeout = Inf,
   time_poll = NULL,
   progress = NULL
@@ -368,6 +383,10 @@ against.}
 \item{\code{envir}}{The environment to use to try and find the function}
 
 \item{\code{queue}}{The queue to add the tasks to (see \verb{$enqueue} for
+details).}
+
+\item{\code{separate_process}}{Logical, indicating if the task should be
+run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
 \item{\code{timeout}}{Optional timeout, in seconds, after which an
@@ -401,6 +420,7 @@ be copied over rather than using their names if possible.
   dots = NULL,
   envir = parent.frame(),
   queue = NULL,
+  separate_process = FALSE,
   timeout = Inf,
   time_poll = NULL,
   progress = NULL
@@ -423,6 +443,10 @@ against.}
 \item{\code{envir}}{The environment to use to try and find the function}
 
 \item{\code{queue}}{The queue to add the tasks to (see \verb{$enqueue} for
+details).}
+
+\item{\code{separate_process}}{Logical, indicating if the task should be
+run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
 \item{\code{timeout}}{Optional timeout, in seconds, after which an

--- a/tests/testthat/myfuns.R
+++ b/tests/testthat/myfuns.R
@@ -46,12 +46,16 @@ run_with_progress_interactive <- function(path, poll = 0.01) {
   while (!file.exists(path)) {
     Sys.sleep(poll)
   }
+  last_write <- ""
   repeat {
     contents <- readLines(path)
     if (identical(contents, "STOP")) {
       break
     }
-    rrq::rrq_task_progress_update(sprintf("Got contents '%s'", contents))
+    if (contents != last_write) {
+      rrq::rrq_task_progress_update(sprintf("Got contents '%s'", contents))
+      last_write <- contents
+    }
     Sys.sleep(poll)
   }
   rrq::rrq_task_progress_update("Finishing")

--- a/tests/testthat/myfuns.R
+++ b/tests/testthat/myfuns.R
@@ -73,3 +73,10 @@ run_with_progress_signal <- function(n, wait) {
   }
   n
 }
+
+
+dirty_double <- function(value) {
+  prev <- .GlobalEnv$.rrq_dirty_double
+  .GlobalEnv$.rrq_dirty_double <- value
+  list(prev, value * 2)
+}

--- a/tests/testthat/test-rrq-progress.R
+++ b/tests/testthat/test-rrq-progress.R
@@ -62,6 +62,7 @@ test_that("update progress multiple times in task", {
 
   writeLines("STOP", p)
   wait_status(t, obj, status = TASK_RUNNING)
+  expect_equal(obj$task_status(t), set_names(TASK_COMPLETE, t))
   expect_equal(obj$task_progress(t),
                "Finishing")
 })

--- a/tests/testthat/test-rrq-progress.R
+++ b/tests/testthat/test-rrq-progress.R
@@ -127,6 +127,7 @@ test_that("collect progress from separate process", {
 
   writeLines("STOP", p)
   wait_status(t, obj, status = TASK_RUNNING)
+  expect_equal(obj$task_status(t), set_names(TASK_COMPLETE, t))
   expect_equal(obj$task_progress(t),
                "Finishing")
 })

--- a/tests/testthat/test-rrq-progress.R
+++ b/tests/testthat/test-rrq-progress.R
@@ -108,9 +108,11 @@ test_that("collect progress from separate process", {
                    separate_process = TRUE)
   wait_status(t, obj)
 
-  Sys.sleep(0.2)
-  expect_equal(obj$task_progress(t),
-               "Waiting for file")
+  testthat::try_again(5, {
+    Sys.sleep(0.5)
+    expect_equal(obj$task_progress(t),
+                 "Waiting for file")
+  })
 
   writeLines("something", p)
   Sys.sleep(0.2)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -307,6 +307,7 @@ test_that("queue remove", {
 ## called as expected but given how simple the function is it seems
 ## like the test really just implements the function like that.
 test_that("worker_send_signal", {
+  skip_if_not_installed("heartbeatr")
   obj <- test_rrq()
   w1 <- test_worker_blocking(obj)
   w2 <- test_worker_blocking(obj)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -417,3 +417,15 @@ test_that("Query jobs in different queues", {
   expect_equal(obj$queue_length("a"), 2)
   expect_equal(obj$queue_list("a"), c(t2, t3))
 })
+
+
+test_that("Send job to new process", {
+  obj <- test_rrq("myfuns.R")
+  w <- test_worker_blocking(obj)
+
+  t <- obj$enqueue(slowdouble(0.1), separate_process = TRUE)
+  expect_is(t, "character")
+  w$step(TRUE)
+  expect_equal(obj$task_wait(t, 2), 0.2)
+  expect_equal(obj$task_result(t), 0.2)
+})

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -420,6 +420,7 @@ test_that("Query jobs in different queues", {
 
 
 test_that("Send job to new process", {
+  skip_if_not_installed("callr")
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
 


### PR DESCRIPTION
This PR adds the ability to run a worker job in a transient process using callr. It is incomplete, but you can try it out in hintr before we finish it. The interface is an argument `separate_process = TRUE` to functions like `$enqueue()`.

* I am not completely sold on `separate_process = TRUE` as a name; we also use "local" for the key (much shorter) and "remote" to describe the separate process. However, what argument we expose should have a default of `FALSE` as these are easier to understand.
* The testing is extremely minimal and does not actually make sure that the job even ran on a different process! ~We need to include some tests that logging works as expected at least as that was the motivation for this, but we might also write a function that pollutes the global environment~
* The core implementation is extremely simple now and shares basically all the worker setup code. This means that the remote will collect any packages and source files that the parent worker uses
* callr is Suggests only; I think that might be ok, what do you think?