### PR TITLE
mrc-2162: Migrate from heartbeatr to redux builtin support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.12
+Version: 0.2.13
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.
@@ -13,13 +13,12 @@ Imports:
     docopt,
     ids,
     progress,
-    redux (>= 1.0.0)
+    redux (>= 1.2.0)
 Suggests:
-    heartbeatr,
     storr,
     testthat
 RoxygenNote: 7.1.1
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-Remotes: mrc-ide/heartbeatr
+Remotes: richfitz/redux@heartbeat
 Language: en-GB

--- a/R/heartbeat.R
+++ b/R/heartbeat.R
@@ -2,9 +2,8 @@ heartbeat <- function(con, keys, period, verbose) {
   if (!is.null(period)) {
     key <- keys$worker_heartbeat
     worker_log(con, keys, "HEARTBEAT", key, verbose)
-    loadNamespace("heartbeatr")
     config <- con$config()
-    ret <- heartbeatr::heartbeat(key, period, config = config)
+    ret <- redux::heartbeat(key, period, config = config)
     worker_log(con, keys, "HEARTBEAT", "OK", verbose)
     ret
   }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -726,8 +726,8 @@ rrq_controller_ <- R6::R6Class(
     ##'   "low")`) to set the position of the default queue.
     ##'
     ##' @param heartbeat_period Optional period for the heartbeat.  If
-    ##'   non-NULL then a heartbeat process will be started (using the
-    ##'   \code{heartbeatr} package) which can be used to build fault
+    ##'   non-NULL then a heartbeat process will be started (using
+    ##'   [redux::heartbeat]) which can be used to build fault
     ##'   tolerant queues.
     ##'
     ##' @param verbose Logical, indicating if the worker should print
@@ -1016,7 +1016,7 @@ task_cancel <- function(con, keys, task_id) {
     stop("Worker does not have heartbeat enabled")
   }
 
-  heartbeatr::heartbeat_send_signal(con, heartbeat_key, tools::SIGINT)
+  redux::heartbeat_send_signal(con, heartbeat_key, tools::SIGINT)
   invisible(TRUE)
 }
 
@@ -1180,7 +1180,7 @@ worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
            paste(worker_ids[is.na(heartbeat_key)], collapse = ", "))
     }
     for (key in heartbeat_key) {
-      heartbeatr::heartbeat_send_signal(con, key, tools::SIGTERM)
+      redux::heartbeat_send_signal(con, key, tools::SIGTERM)
     }
   } else { # kill_local
     info <- worker_info(con, keys, worker_ids)

--- a/R/worker.R
+++ b/R/worker.R
@@ -23,8 +23,8 @@
 ##'   run by all workers.
 ##'
 ##' @param heartbeat_period Optional period for the heartbeat.  If
-##'   non-NULL then a heartbeat process will be started (using the
-##'   \code{heartbeatr} package) which can be used to build fault
+##'   non-NULL then a heartbeat process will be started (using
+##'   [redux::heartbeat]) which can be used to build fault
 ##'   tolerant queues.
 ##'
 ##' @param verbose Logical, indicating if the worker should print
@@ -225,7 +225,7 @@ rrq_worker_stop <- function(worker, message) {
 worker_send_signal <- function(con, keys, signal, worker_ids) {
   if (length(worker_ids) > 0L) {
     for (key in rrq_key_worker_heartbeat(keys$queue_id, worker_ids)) {
-      heartbeatr::heartbeat_send_signal(con, key, signal)
+      redux::heartbeat_send_signal(con, key, signal)
     }
   }
 }

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -1106,8 +1106,8 @@ and jobs put onto these queues with \verb{$enqueue()} will have
 the "default" queue (e.g., \code{queue = c("high", "default", "low")}) to set the position of the default queue.}
 
 \item{\code{heartbeat_period}}{Optional period for the heartbeat.  If
-non-NULL then a heartbeat process will be started (using the
-\code{heartbeatr} package) which can be used to build fault
+non-NULL then a heartbeat process will be started (using
+\link[redux:heartbeat]{redux::heartbeat}) which can be used to build fault
 tolerant queues.}
 
 \item{\code{verbose}}{Logical, indicating if the worker should print

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -42,8 +42,8 @@ after initialising the worker, except that it's guaranteed to be
 run by all workers.}
 
 \item{heartbeat_period}{Optional period for the heartbeat.  If
-non-NULL then a heartbeat process will be started (using the
-\code{heartbeatr} package) which can be used to build fault
+non-NULL then a heartbeat process will be started (using
+\link[redux:heartbeat]{redux::heartbeat}) which can be used to build fault
 tolerant queues.}
 
 \item{verbose}{Logical, indicating if the worker should print

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -177,7 +177,6 @@ test_that("Timer is recreated after task run", {
 
 
 test_that("kill worker with a signal", {
-  skip_if_not_installed("heartbeatr")
   skip_on_os("windows")
 
   obj <- test_rrq()

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -301,9 +301,9 @@ test_that("queue remove", {
 
 ## This is not ideal, but should do for now. The worker_send_signal
 ## function is not yet widely used from the controller, but will be at
-## some point. We depend on a implementation detail of heartbeatr, but
+## some point. We depend on a implementation detail of redux::heartbeat, but
 ## it's one that I think I have documented. The alternative would be
-## to mock this and ensure that heartbeatr::heartbeat_send_signal is
+## to mock this and ensure that redux::heartbeat_send_signal is
 ## called as expected but given how simple the function is it seems
 ## like the test really just implements the function like that.
 test_that("worker_send_signal", {

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -1,7 +1,6 @@
 context("fault tolerance")
 
 test_that("heartbeat", {
-  skip_if_not_installed("heartbeatr")
   obj <- test_rrq()
 
   res <- obj$worker_config_save("localhost", heartbeat_period = 3)
@@ -75,7 +74,6 @@ test_that("interrupt stuck worker (local)", {
 })
 
 test_that("interrupt stuck worker (via heartbeat)", {
-  skip_if_not_installed("heartbeatr")
   ## Basically the same test as above, but we'll do it via the
   ## heartbeat thread.  These might be worth merging.
   skip_on_os("windows")
@@ -122,7 +120,6 @@ test_that("interrupt stuck worker (via heartbeat)", {
 
 
 test_that("Stop task with interrupt", {
-  skip_if_not_installed("heartbeatr")
   skip_on_os("windows")
   obj <- test_rrq("myfuns.R")
 
@@ -162,7 +159,6 @@ test_that("Stop task with interrupt", {
 
 
 test_that("race conditioning handling when cancelling tasks", {
-  skip_if_not_installed("heartbeatr")
   skip_on_os("windows")
 
   obj <- test_rrq("myfuns.R")
@@ -215,7 +211,6 @@ test_that("detecting workers with no heartbeat is quiet", {
 
 
 test_that("detecting output with clean exit is quiet", {
-  skip_if_not_installed("heartbeatr")
   obj <- test_rrq("myfuns.R")
 
   ## We need to set time_poll to be fairly fast because BLPOP is not
@@ -247,7 +242,6 @@ test_that("detecting output with clean exit is quiet", {
 
 
 test_that("detect killed worker (via heartbeat)", {
-  skip_if_not_installed("heartbeatr")
   obj <- test_rrq("myfuns.R")
 
   ## We need to set time_poll to be fairly fast because BLPOP is not
@@ -296,7 +290,6 @@ test_that("detect killed worker (via heartbeat)", {
 
 ## See https://github.com/mrc-ide/rrq/issues/22
 test_that("detect multiple killed workers", {
-  skip_if_not_installed("heartbeatr")
   obj <- test_rrq("myfuns.R")
 
   res <- obj$worker_config_save("localhost", time_poll = 1,


### PR DESCRIPTION
This PR moves away from heartbeatr (which can be retired) to builtin heartbeat support introduced in redux 1.2.0