### PR TITLE
mrc-2270: Deferred tasks get added to correct queue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.15
+Version: 0.2.16
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -9,8 +9,8 @@ worker_queue_dependencies <- function(worker, task_id, task_status) {
     cancel_dependencies(worker$con, worker$keys, worker$queue_deferred,
                         dependent_ids)
   } else {
-    queue_dependencies(worker$con, worker$keys, worker$queue,
-                       worker$queue_deferred, task_id, dependent_ids)
+    queue_dependencies(worker$con, worker$keys, worker$queue_deferred,
+                       task_id, dependent_ids)
   }
   invisible(TRUE)
 }
@@ -28,8 +28,8 @@ cancel_dependencies <- function(con, keys, queue_deferred, ids) {
   }
 }
 
-queue_dependencies <- function(con, keys, queue, queue_deferred,
-                               task_id, deferred_task_ids) {
+queue_dependencies <- function(con, keys, queue_deferred, task_id,
+                               deferred_task_ids) {
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(
     lapply(dependency_keys, redis$SREM, task_id),
@@ -37,13 +37,16 @@ queue_dependencies <- function(con, keys, queue, queue_deferred,
   )
 
   ## Tasks with 0 remaining dependencies can be queued
+  browser()
   tasks_to_queue <- names(res[res == 0 & names(res) != ""])
-  cmds <- lapply(tasks_to_queue, function(id) {
+  queue_keys <- con$HMGET(keys$task_queue, tasks_to_queue)
+  queue_task <- function(id, key_queue) {
     list(
       redis$SREM(queue_deferred, id),
-      redis$LPUSH(queue, id),
+      redis$LPUSH(key_queue, id),
       redis$HMSET(keys$task_status, id, TASK_PENDING)
     )
-  })
+  }
+  cmds <- Map(queue_task, tasks_to_queue, queue_keys)
   con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -38,15 +38,17 @@ queue_dependencies <- function(con, keys, queue_deferred, task_id,
 
   ## Tasks with 0 remaining dependencies can be queued
   tasks_to_queue <- names(res[res == 0 & names(res) != ""])
-  task_queues <- con$HMGET(keys$task_queue, tasks_to_queue)
-  queue_keys <- rrq_key_queue(keys$queue_id, task_queues)
-  queue_task <- function(id, queue_key) {
-    list(
-      redis$SREM(queue_deferred, id),
-      redis$LPUSH(queue_key, id),
-      redis$HMSET(keys$task_status, id, TASK_PENDING)
-    )
+  if (length(tasks_to_queue > 0)) {
+    task_queues <- con$HMGET(keys$task_queue, tasks_to_queue)
+    queue_keys <- rrq_key_queue(keys$queue_id, task_queues)
+    queue_task <- function(id, queue_key) {
+      list(
+        redis$SREM(queue_deferred, id),
+        redis$LPUSH(queue_key, id),
+        redis$HMSET(keys$task_status, id, TASK_PENDING)
+      )
+    }
+    cmds <- Map(queue_task, tasks_to_queue, queue_keys)
+    con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
   }
-  cmds <- Map(queue_task, tasks_to_queue, queue_keys)
-  con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
 }

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -39,7 +39,7 @@ queue_dependencies <- function(con, keys, deferred_set, task_id,
   ## Tasks with 0 remaining dependencies can be queued
   tasks_to_queue <- names(res[res == 0 & names(res) != ""])
   if (length(tasks_to_queue > 0)) {
-    task_queues <- con$HMGET(keys$task_queue, tasks_to_queue)
+    task_queues <- list_to_character(con$HMGET(keys$task_queue, tasks_to_queue))
     queue_keys <- rrq_key_queue(keys$queue_id, task_queues)
     queue_task <- function(id, queue_key) {
       list(

--- a/R/keys.R
+++ b/R/keys.R
@@ -35,7 +35,7 @@ rrq_keys_common <- function(queue_id) {
        task_result    = sprintf("%s:task:result",    queue_id),
        task_complete  = sprintf("%s:task:complete",  queue_id),
 
-       queue_deferred = sprintf("%s:queue:deferred", queue_id))
+       deferred_set   = sprintf("%s:deferred", queue_id))
 }
 
 rrq_keys_worker <- function(queue, worker) {

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1126,7 +1126,7 @@ task_submit_n <- function(con, keys, dat, key_complete, queue,
       lapply(original_deps_keys, redis$SADD, depends_on),
       lapply(dependency_keys, redis$SADD, depends_on),
       lapply(dependent_keys, redis$SADD, task_ids),
-      list(redis$SADD(keys$queue_deferred, task_ids))
+      list(redis$SADD(keys$deferred_set, task_ids))
     )
   } else if (at_front) {
     cmds <- c(cmds, list(redis$LPUSH(key_queue, task_ids)))
@@ -1139,7 +1139,7 @@ task_submit_n <- function(con, keys, dat, key_complete, queue,
   incomplete_status <- c(TASK_ERROR, TASK_ORPHAN, TASK_INTERRUPTED,
                          TASK_IMPOSSIBLE)
   if (any(response$status %in% incomplete_status)) {
-    cancel_dependencies(con, keys, keys$queue_deferred, task_ids)
+    cancel_dependencies(con, keys, keys$deferred_set, task_ids)
     incomplete <- response$status[response$status %in% incomplete_status]
     names(incomplete) <- depends_on[response$status %in% incomplete_status]
     stop(sprintf("Failed to queue as dependent tasks failed:\n%s",
@@ -1149,7 +1149,7 @@ task_submit_n <- function(con, keys, dat, key_complete, queue,
 
   complete <- depends_on[response$status == TASK_COMPLETE]
   for (dep_id in complete) {
-    queue_dependencies(con, keys, keys$queue_deferred, dep_id, task_ids)
+    queue_dependencies(con, keys, keys$deferred_set, dep_id, task_ids)
   }
 
   task_ids

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1149,8 +1149,7 @@ task_submit_n <- function(con, keys, dat, key_complete, queue,
 
   complete <- depends_on[response$status == TASK_COMPLETE]
   for (dep_id in complete) {
-    queue_dependencies(con, keys, key_queue, keys$queue_deferred, dep_id,
-                       task_ids)
+    queue_dependencies(con, keys, keys$queue_deferred, dep_id, task_ids)
   }
 
   task_ids

--- a/R/worker.R
+++ b/R/worker.R
@@ -56,7 +56,7 @@ rrq_worker_ <- R6::R6Class(
     envir = NULL,
     keys = NULL,
     queue = NULL,
-    queue_deferred = NULL,
+    deferred_set = NULL,
     con = NULL,
     db = NULL,
     paused = FALSE,
@@ -83,7 +83,7 @@ rrq_worker_ <- R6::R6Class(
 
       queue <- worker_queue(queue)
       self$queue <- rrq_key_queue(queue_id, queue)
-      self$queue_deferred <- self$keys$queue_deferred
+      self$deferred_set <- self$keys$deferred_set
       self$log("QUEUE", queue)
 
       if (self$con$SISMEMBER(self$keys$worker_name, self$name) == 1L) {

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -157,8 +157,8 @@ test_that("bulk tasks can be queued with dependency", {
   }
 
   ## Items are in deferred queue
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_setequal(obj$con$SMEMBERS(key_queue_deferred), c(grp$task_ids, t3))
+  deferred_set <- obj$keys$deferred_set
+  expect_setequal(obj$con$SMEMBERS(deferred_set), c(grp$task_ids, t3))
 
   w$step(TRUE)
   obj$task_wait(t, 2)
@@ -174,21 +174,21 @@ test_that("bulk tasks can be queued with dependency", {
   expect_equivalent(obj$task_status(t3), "DEFERRED")
   queue <- obj$queue_list()
   expect_setequal(queue, grp$task_ids)
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list(t3))
+  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   obj$task_wait(queue[1], 2)
   expect_setequal(obj$task_status(grp$task_ids), c("COMPLETE", "PENDING"))
   expect_equivalent(obj$task_status(t3), "DEFERRED")
   expect_equal(obj$queue_list(), queue[2])
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list(t3))
+  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   obj$task_wait(queue[2], 2)
   expect_equivalent(obj$task_status(grp$task_ids), c("COMPLETE", "COMPLETE"))
   expect_equivalent(obj$task_status(t3), "PENDING")
   expect_equal(obj$queue_list(), t3)
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 
   w$step(TRUE)
   obj$task_wait(t3, 2)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -502,9 +502,9 @@ test_that("task can be queued with dependency", {
     expect_equal(obj$con$SMEMBERS(key), list(t3))
   }
 
-  ## t3 is on dependency queue
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list(t3))
+  ## t3 is in deferred set
+  deferred_set <- obj$keys$deferred_set
+  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   ## Function to retrieve status of t3 and see what it is waiting for
 
@@ -518,7 +518,7 @@ test_that("task can be queued with dependency", {
   ## Status of it has updated
   expect_setequal(obj$con$SMEMBERS(original_deps_keys), c(t, t2))
   expect_equal(obj$con$SMEMBERS(dependency_keys), list(t2))
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list(t3))
+  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   obj$task_wait(t2, 2)
@@ -529,7 +529,7 @@ test_that("task can be queued with dependency", {
   ## Status can be retrieved
   expect_setequal(obj$con$SMEMBERS(original_deps_keys), c(t, t2))
   expect_equal(obj$con$SMEMBERS(dependency_keys), list())
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 
   w$step(TRUE)
   obj$task_wait(t3, 2)
@@ -566,9 +566,9 @@ test_that("queueing with depends_on errored task fails", {
                       t, ": ERROR"),
                fixed = TRUE)
 
-  ## deferred queue is empty
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  ## deferred set is empty
+  deferred_set <- obj$keys$deferred_set
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 
   ## Task is set to impossible
   status <- obj$task_status()
@@ -601,8 +601,8 @@ test_that("dependent tasks updated if dependency fails", {
   expect_equivalent(obj$task_status(t3), "IMPOSSIBLE")
   expect_equivalent(obj$task_status(t4), "IMPOSSIBLE")
   expect_equal(obj$queue_list(), character(0))
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  deferred_set <- obj$keys$deferred_set
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
 
 test_that("multiple tasks can be queued with same dependency", {
@@ -616,9 +616,9 @@ test_that("multiple tasks can be queued with same dependency", {
   expect_equivalent(obj$task_status(t2), "DEFERRED")
   expect_equivalent(obj$task_status(t3), "DEFERRED")
 
-  ## t3 is on dependency queue
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_setequal(obj$con$SMEMBERS(key_queue_deferred), c(t2, t3))
+  ## t3 is in deferred set
+  deferred_set <- obj$keys$deferred_set
+  expect_setequal(obj$con$SMEMBERS(deferred_set), c(t2, t3))
 
   w$step(TRUE)
   obj$task_wait(t, 2)
@@ -627,7 +627,7 @@ test_that("multiple tasks can be queued with same dependency", {
   expect_equivalent(obj$task_status(t3), "PENDING")
   expect_setequal(obj$queue_list(), c(t2, t3))
 
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
 
 test_that("deferred task is added to specified queue", {
@@ -639,13 +639,13 @@ test_that("deferred task is added to specified queue", {
   t3 <- obj$enqueue(sin(0), depends_on = t, queue = "a")
   expect_equal(obj$queue_list(), t)
   expect_equal(obj$queue_list("a"), character(0))
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_setequal(obj$con$SMEMBERS(key_queue_deferred), list(t2, t3))
+  deferred_set <- obj$keys$deferred_set
+  expect_setequal(obj$con$SMEMBERS(deferred_set), list(t2, t3))
 
   w$step(TRUE)
   obj$task_wait(t, 2)
 
   expect_equal(obj$queue_list(), t2)
   expect_equal(obj$queue_list("a"), t3)
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })


### PR DESCRIPTION
This PR will
* Add 1 deferred "queue" - really this is a set of deferred tasks (previously 1 per queue type)
* When a deferred task gets put onto queue it will be put onto the queue set at submission time