### PR TITLE
mrc-2267: Add test to check impossible task cannot be put onto queue

### DIFF
--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -661,8 +661,8 @@ test_that("task set to impossible cannot be added to queue", {
   expect_equivalent(obj$task_status(t2), "PENDING")
   expect_equivalent(obj$task_status(t3), "DEFERRED")
   expect_equal(obj$queue_list(), c(t, t2))
-  key_queue_deferred <- obj$keys$queue_deferred
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list(t3))
+  deferred_set <- obj$keys$deferred_set
+  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   res <- obj$task_result(t)
@@ -672,7 +672,7 @@ test_that("task set to impossible cannot be added to queue", {
   expect_equivalent(obj$task_status(t2), "PENDING")
   expect_equivalent(obj$task_status(t3), "IMPOSSIBLE")
   expect_equal(obj$queue_list(), t2)
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 
   w$step(TRUE)
   obj$task_wait(t2, 2)
@@ -680,5 +680,5 @@ test_that("task set to impossible cannot be added to queue", {
   expect_equivalent(obj$task_status(t2), "COMPLETE")
   expect_equivalent(obj$task_status(t3), "IMPOSSIBLE")
   expect_equal(obj$queue_list(), character(0))
-  expect_equal(obj$con$SMEMBERS(key_queue_deferred), list())
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })


### PR DESCRIPTION
I mentioned a case where we had task A, B added to queue and C which depends on A & B.

If A failed, it would mark C as impossible
But if B completed successfully then it would put A onto the queue

So I had a test for this which I had removed temporarily which I definitely saw failing, but since adding this test back in it is now working. So I think some code change has fixed this too. Which makes sense because we would only remove A from the list of dependencies of C in the case that it A completes successfully. So what happens is

A fails, marks C as impossible
B completes, checks if it can queue C but it cannot because task A is still in list of dependencies (and will never be removed)

Still good to add the test for this