### PR TITLE
mrc-2268: Add support for delete & cancelling tasks with dependencies and deferred tasks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.2.16
+Version: 0.2.17
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -30,7 +30,7 @@ queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(
     lapply(dependency_keys, redis$SREM, task_id),
-    setNames(lapply(dependency_keys, redis$SCARD), deferred_task_ids))
+    set_names(lapply(dependency_keys, redis$SCARD), deferred_task_ids))
   )
 
   ## Tasks with 0 remaining dependencies can be queued

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -15,9 +15,9 @@ worker_queue_dependencies <- function(worker, task_id, task_status) {
 
 cancel_dependencies <- function(con, keys, ids) {
   dependent_keys <- rrq_key_task_dependents(keys$queue_id, ids)
-  for (dependent_key in dependent_keys) {
-    dependent_ids <- con$SMEMBERS(dependent_key)
-    n <- length(dependent_ids)
+  dependent_ids <- unique(unlist(lapply(dependent_keys, con$SMEMBERS)))
+  n <- length(dependent_ids)
+  if (n > 0) {
     con$pipeline(
       redis$HMSET(keys$task_status, dependent_ids, rep_len(TASK_IMPOSSIBLE, n)),
       redis$SREM(keys$deferred_set, dependent_ids)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -6,25 +6,23 @@ worker_queue_dependencies <- function(worker, task_id, task_status) {
   }
 
   if (identical(task_status, TASK_ERROR)) {
-    cancel_dependencies(worker$con, worker$keys, dependent_ids)
+    cancel_dependencies(worker$con, worker$keys, task_id)
   } else {
     queue_dependencies(worker$con, worker$keys, task_id, dependent_ids)
   }
   invisible(TRUE)
 }
 
-cancel_dependencies <- function(con, keys, ids, dependencies_only = FALSE) {
-  if (!dependencies_only) {
-    n <- length(ids)
-    con$pipeline(
-      redis$HMSET(keys$task_status, ids, rep_len(TASK_IMPOSSIBLE, n)),
-      redis$SREM(keys$deferred_set, ids)
-    )
-  }
+cancel_dependencies <- function(con, keys, ids) {
   dependent_keys <- rrq_key_task_dependents(keys$queue_id, ids)
   for (dependent_key in dependent_keys) {
     dependent_ids <- con$SMEMBERS(dependent_key)
-    cancel_dependencies(con, keys, dependent_ids, dependencies_only = FALSE)
+    n <- length(dependent_ids)
+    con$pipeline(
+      redis$HMSET(keys$task_status, dependent_ids, rep_len(TASK_IMPOSSIBLE, n)),
+      redis$SREM(keys$deferred_set, dependent_ids)
+    )
+    cancel_dependencies(con, keys, dependent_ids)
   }
 }
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -6,34 +6,29 @@ worker_queue_dependencies <- function(worker, task_id, task_status) {
   }
 
   if (identical(task_status, TASK_ERROR)) {
-    cancel_dependencies(worker$con, worker$keys, worker$deferred_set,
-                        dependent_ids)
+    cancel_dependencies(worker$con, worker$keys, dependent_ids)
   } else {
-    queue_dependencies(worker$con, worker$keys, worker$deferred_set,
-                       task_id, dependent_ids)
+    queue_dependencies(worker$con, worker$keys, task_id, dependent_ids)
   }
   invisible(TRUE)
 }
 
-cancel_dependencies <- function(con, keys, deferred_set, ids,
-                                dependencies_only = FALSE) {
+cancel_dependencies <- function(con, keys, ids, dependencies_only = FALSE) {
   if (!dependencies_only) {
     n <- length(ids)
     con$pipeline(
       redis$HMSET(keys$task_status, ids, rep_len(TASK_IMPOSSIBLE, n)),
-      redis$SREM(deferred_set, ids)
+      redis$SREM(keys$deferred_set, ids)
     )
   }
   dependent_keys <- rrq_key_task_dependents(keys$queue_id, ids)
   for (dependent_key in dependent_keys) {
     dependent_ids <- con$SMEMBERS(dependent_key)
-    cancel_dependencies(con, keys, deferred_set, dependent_ids,
-                        dependencies_only = FALSE)
+    cancel_dependencies(con, keys, dependent_ids, dependencies_only = FALSE)
   }
 }
 
-queue_dependencies <- function(con, keys, deferred_set, task_id,
-                               deferred_task_ids) {
+queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(
     lapply(dependency_keys, redis$SREM, task_id),
@@ -47,7 +42,7 @@ queue_dependencies <- function(con, keys, deferred_set, task_id,
     queue_keys <- rrq_key_queue(keys$queue_id, task_queues)
     queue_task <- function(id, queue_key) {
       list(
-        redis$SREM(deferred_set, id),
+        redis$SREM(keys$deferred_set, id),
         redis$LPUSH(queue_key, id),
         redis$HMSET(keys$task_status, id, TASK_PENDING)
       )

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1001,21 +1001,46 @@ task_delete <- function(con, keys, task_ids, check = TRUE) {
     keys$queue_id, task_ids)
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, task_ids)
   dependent_keys <- rrq_key_task_dependents(keys$queue_id, task_ids)
-  con$pipeline(.commands = c(list(
-    redis$HDEL(keys$task_expr,     task_ids),
-    redis$HDEL(keys$task_status,   task_ids),
-    redis$HDEL(keys$task_result,   task_ids),
-    redis$HDEL(keys$task_complete, task_ids),
-    redis$HDEL(keys$task_progress, task_ids),
-    redis$HDEL(keys$task_worker,   task_ids),
-    redis$HDEL(keys$task_local,    task_ids),
-    redis$SREM(keys$deferred_set,  task_ids)),
+  res <- con$pipeline(.commands = c(
+    setNames(lapply(task_ids, function(x) redis$HGET(keys$task_status, x)),
+             paste0("status_", task_ids)),
+    setNames(lapply(dependent_keys, redis$SMEMBERS), task_ids),
+    list(
+      redis$HDEL(keys$task_expr,     task_ids),
+      redis$HDEL(keys$task_status,   task_ids),
+      redis$HDEL(keys$task_result,   task_ids),
+      redis$HDEL(keys$task_complete, task_ids),
+      redis$HDEL(keys$task_progress, task_ids),
+      redis$HDEL(keys$task_worker,   task_ids),
+      redis$HDEL(keys$task_local,    task_ids),
+      redis$SREM(keys$deferred_set,  task_ids)
+    ),
     lapply(original_deps_keys, redis$DEL),
     lapply(dependency_keys, redis$DEL),
     lapply(dependent_keys, redis$DEL)
     ))
   queue <- list_to_character(con$HMGET(keys$task_queue, task_ids))
   queue_remove(con, keys, task_ids, queue)
+
+  ## We only want to cancel dependencies i.e. set status to IMPOSSIBLE when
+  ## A. They are dependents of a task which is PENDING or DEFERRED AND
+  ## B. Their dependencies have not already been set to MISSING, ERROED, etc.
+  ## i.e. their dependencies are also PENDING or DEFERRED
+  status <- res[grepl("status_", names(res))]
+  ids_to_cancel <- task_ids[unlist(status) %in% c(TASK_PENDING, TASK_DEFERRED)]
+  dependents <- unique(unlist(res[ids_to_cancel]))
+  if (length(dependents) > 0) {
+    status_dependent <- con$HMGET(keys$task_status, dependents)
+    cancel <- dependents[status_dependent %in% c(TASK_PENDING, TASK_DEFERRED)]
+    if (length(cancel) > 0) {
+      con$pipeline(
+        redis$HMSET(keys$task_status, cancel,
+                    rep_len(TASK_IMPOSSIBLE, length(cancel))),
+        redis$SREM(keys$deferred_set, cancel)
+      )
+      cancel_dependencies(con, keys, cancel)
+    }
+  }
 
   invisible()
 }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1023,7 +1023,7 @@ task_delete <- function(con, keys, task_ids, check = TRUE) {
 
   ## We only want to cancel dependencies i.e. set status to IMPOSSIBLE when
   ## A. They are dependents of a task which is PENDING or DEFERRED AND
-  ## B. Their dependencies have not already been deleted or set to ERROED, etc.
+  ## B. Their dependencies have not already been deleted or set to ERRORED, etc.
   ## i.e. their dependencies are also DEFERRED
   status <- res[seq_along(task_ids)]
   ids_to_cancel <- task_ids[unlist(status) %in% c(TASK_PENDING, TASK_DEFERRED)]

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1053,7 +1053,7 @@ task_cancel <- function(con, keys, task_id) {
     dat$status <- TASK_MISSING
   }
 
-  if (dat$status %in% c(TASK_PENDING, TASK_DEFERRED, TASK_IMPOSSIBLE)) {
+  if (dat$status %in% c(TASK_PENDING, TASK_DEFERRED)) {
     cancel_dependencies(con, keys, keys$deferred_set, task_id)
     task_delete(con, keys, task_id, FALSE)
     dat <- con$pipeline(

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -536,6 +536,7 @@ test_that("task can be queued with dependency", {
   expect_equivalent(obj$task_status(t3), "COMPLETE")
 })
 
+
 test_that("task added to queue immediately if dependencies satified", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
@@ -551,6 +552,7 @@ test_that("task added to queue immediately if dependencies satified", {
   expect_equal(obj$queue_list(), t2)
   expect_equivalent(obj$task_status(t2), TASK_PENDING)
 })
+
 
 test_that("queueing with depends_on errored task fails", {
   obj <- test_rrq("myfuns.R")
@@ -576,6 +578,7 @@ test_that("queueing with depends_on errored task fails", {
   expect_true(TASK_IMPOSSIBLE %in% status)
   expect_true(TASK_ERROR %in% status)
 })
+
 
 test_that("dependent tasks updated if dependency fails", {
   obj <- test_rrq("myfuns.R")
@@ -605,6 +608,7 @@ test_that("dependent tasks updated if dependency fails", {
   expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
 
+
 test_that("multiple tasks can be queued with same dependency", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
@@ -630,6 +634,7 @@ test_that("multiple tasks can be queued with same dependency", {
   expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
 
+
 test_that("deferred task is added to specified queue", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
@@ -649,6 +654,7 @@ test_that("deferred task is added to specified queue", {
   expect_equal(obj$queue_list("a"), t3)
   expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
+
 
 test_that("task set to impossible cannot be added to queue", {
   obj <- test_rrq("myfuns.R")
@@ -683,28 +689,69 @@ test_that("task set to impossible cannot be added to queue", {
   expect_equal(obj$con$SMEMBERS(deferred_set), list())
 })
 
+
 test_that("deferred task delete", {
+  obj <- test_rrq("myfuns.R")
+  t1 <- obj$enqueue(1 + 1)
+  t2 <- obj$enqueue(2 + 2, depends_on = t1)
+  t3 <- obj$enqueue(2 + 2, depends_on = t1)
+  t4 <- obj$enqueue(2 + 2, depends_on = t3)
+
+  expect_setequal(obj$task_list(), c(t1, t2, t3, t4))
+  expect_equal(obj$queue_list(), t1)
+  deferred_set <- obj$keys$deferred_set
+  expect_setequal(obj$con$SMEMBERS(deferred_set), list(t2, t3, t4))
+
+  obj$task_delete(t2)
+  expect_setequal(obj$task_list(), c(t1, t3, t4))
+  expect_equal(obj$queue_list(), t1)
+  expect_setequal(obj$con$SMEMBERS(deferred_set), list(t3, t4))
+  expect_equivalent(obj$task_status(t1), "PENDING")
+  expect_equivalent(obj$task_status(t2), "MISSING")
+  expect_equivalent(obj$task_status(t3), "DEFERRED")
+  expect_equivalent(obj$task_status(t4), "DEFERRED")
+
+  obj$task_delete(t1)
+  expect_setequal(obj$task_list(), c(t3, t4))
+  expect_setequal(obj$queue_list(), character(0))
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
+  expect_equivalent(obj$task_status(t1), "MISSING")
+  expect_equivalent(obj$task_status(t2), "MISSING")
+  expect_equivalent(obj$task_status(t3), "IMPOSSIBLE")
+  expect_equivalent(obj$task_status(t4), "IMPOSSIBLE")
+
+  obj$task_delete(t3)
+  expect_setequal(obj$task_list(), t4)
+  expect_setequal(obj$queue_list(), character(0))
+  expect_equal(obj$con$SMEMBERS(deferred_set), list())
+  expect_equivalent(obj$task_status(t1), "MISSING")
+  expect_equivalent(obj$task_status(t2), "MISSING")
+  expect_equivalent(obj$task_status(t3), "MISSING")
+  expect_equivalent(obj$task_status(t4), "IMPOSSIBLE")
+})
+
+
+test_that("delete completed task does not clear dependencies", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
   t1 <- obj$enqueue(1 + 1)
   t2 <- obj$enqueue(2 + 2, depends_on = t1)
-  t3 <- obj$enqueue(2 + 2, depends_on = t1)
 
-  expect_setequal(obj$task_list(), c(t1, t2, t3))
-  expect_equal(obj$queue_list(), t1)
-  deferred_set <- obj$keys$deferred_set
-  expect_setequal(obj$con$SMEMBERS(deferred_set), list(t2, t3))
+  w$step(TRUE)
+  obj$task_wait(t1, 2)
 
-  obj$task_delete(t2)
-  expect_setequal(obj$task_list(), c(t1, t3))
-  expect_equal(obj$queue_list(), t1)
-  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
+  expect_setequal(obj$task_list(), c(t1, t2))
+  expect_equal(obj$queue_list(), t2)
+  expect_equivalent(obj$task_status(t1), "COMPLETE")
+  expect_equivalent(obj$task_status(t2), "PENDING")
 
   obj$task_delete(t1)
-  expect_setequal(obj$task_list(), t3)
-  expect_setequal(obj$queue_list(), character(0))
-  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
+  expect_setequal(obj$task_list(), t2)
+  expect_equal(obj$queue_list(), t2)
+  expect_equivalent(obj$task_status(t1), "MISSING")
+  expect_equivalent(obj$task_status(t2), "PENDING")
 })
+
 
 test_that("deferred task cancel", {
   obj <- test_rrq("myfuns.R")


### PR DESCRIPTION
* Deferred tasks can be cancelled & deleted
* Tasks cancelled which have dependencies will mark these as impossible (where they cannot be resolved)