### PR TITLE
mrc-2341: allow timeout for tasks submitted to separate process

### DIFF
--- a/R/bulk.R
+++ b/R/bulk.R
@@ -1,29 +1,31 @@
 rrq_lapply <- function(con, keys, db, x, fun, dots, envir, queue,
-                       separate_process, depends_on, timeout, time_poll,
-                       progress) {
+                       separate_process, task_timeout, depends_on,
+                       collect_timeout, time_poll, progress) {
   dat <- rrq_bulk_submit(con, keys, db, x, fun, dots, FALSE, envir, queue,
-                         separate_process, depends_on)
-  if (timeout == 0) {
+                         separate_process, task_timeout, depends_on)
+  if (collect_timeout == 0) {
     return(dat)
   }
-  rrq_bulk_wait(con, keys, dat, timeout, time_poll, progress)
+  rrq_bulk_wait(con, keys, dat, collect_timeout, time_poll, progress)
 }
 
 
 rrq_enqueue_bulk <- function(con, keys, db, x, fun, dots,
-                             envir, queue, separate_process, depends_on,
-                             timeout, time_poll, progress) {
+                             envir, queue, separate_process, task_timeout,
+                             depends_on, collect_timeout, time_poll, progress) {
   dat <- rrq_bulk_submit(con, keys, db, x, fun, dots, TRUE,
-                         envir, queue, separate_process, depends_on)
-  if (timeout == 0) {
+                         envir, queue, separate_process, task_timeout,
+                         depends_on)
+  if (collect_timeout == 0) {
     return(dat)
   }
-  rrq_bulk_wait(con, keys, dat, timeout, time_poll, progress)
+  rrq_bulk_wait(con, keys, dat, collect_timeout, time_poll, progress)
 }
 
 
 rrq_bulk_submit <- function(con, keys, db, x, fun, dots, do_call,
-                            envir, queue, separate_process, depends_on) {
+                            envir, queue, separate_process, task_timeout,
+                            depends_on) {
   fun <- match_fun_envir(fun, envir)
   if (do_call) {
     x <- rrq_bulk_prepare_call_x(x)
@@ -34,7 +36,8 @@ rrq_bulk_submit <- function(con, keys, db, x, fun, dots, do_call,
 
   key_complete <- rrq_key_task_complete(keys$queue_id)
   task_ids <- task_submit_n(con, keys, dat, key_complete, queue,
-                            separate_process, depends_on = depends_on)
+                            separate_process, task_timeout,
+                            depends_on = depends_on)
   ret <- list(task_ids = task_ids, key_complete = key_complete,
               names = names(x))
   class(ret) <- "rrq_bulk"

--- a/R/common.R
+++ b/R/common.R
@@ -13,6 +13,8 @@ TASK_ERROR    <- "ERROR"
 TASK_CANCELLED <- "CANCELLED"
 ## task (or its worker) was killed or crashed
 TASK_DIED <- "DIED"
+## task took too long and was stopped due to timeout
+TASK_TIMEOUT <- "TIMEOUT"
 ## An unknown task
 TASK_MISSING  <- "MISSING"
 

--- a/R/keys.R
+++ b/R/keys.R
@@ -31,6 +31,7 @@ rrq_keys_common <- function(queue_id) {
        task_worker    = sprintf("%s:task:worker",    queue_id),
        task_queue     = sprintf("%s:task:queue",     queue_id),
        task_local     = sprintf("%s:task:local",     queue_id),
+       task_timeout   = sprintf("%s:task:timeout",   queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
        task_complete  = sprintf("%s:task:complete",  queue_id),

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -271,6 +271,7 @@ Queue an expression
   key_complete = NULL,
   queue = NULL,
   separate_process = FALSE,
+  timeout = NULL,
   at_front = FALSE,
   depends_on = NULL
 )}\if{html}{\out{</div>}}
@@ -304,6 +305,11 @@ clean, subsequent runs are not affected by preceeding ones.
 The downside of this approach is a considerable overhead in
 starting the extenal process and transferring data back.}
 
+\item{\code{timeout}}{Optionally, a maximum allowed running time, in
+seconds. This parameter only has an effect if \code{separate_process}
+is \code{TRUE}. If given, then if the task takes longer than this
+time it will be stopped and the task status set to \code{TIMEOUT}.}
+
 \item{\code{at_front}}{Logical, if TRUE then add the task to the front
 of the queue.}
 
@@ -328,6 +334,7 @@ Queue an expression
   key_complete = NULL,
   queue = NULL,
   separate_process = FALSE,
+  timeout = NULL,
   at_front = FALSE,
   depends_on = NULL
 )}\if{html}{\out{</div>}}
@@ -360,6 +367,9 @@ push jobs onto a queue with no worker, it will queue forever.}
 run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
+\item{\code{timeout}}{Optionally, a maximum allowed running time, in
+seconds (see \verb{$enqueue} for details).}
+
 \item{\code{at_front}}{Logical, if TRUE then add the task to the front
 of the queue.}
 
@@ -387,8 +397,9 @@ equivalent to using \verb{$enqueue()} over each element in the list.
   envir = parent.frame(),
   queue = NULL,
   separate_process = FALSE,
+  task_timeout = NULL,
   depends_on = NULL,
-  timeout = Inf,
+  collect_timeout = Inf,
   time_poll = NULL,
   progress = NULL
 )}\if{html}{\out{</div>}}
@@ -416,6 +427,9 @@ details).}
 run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
+\item{\code{task_timeout}}{Optionally, a maximum allowed running time, in
+seconds (see the \code{timeout} argument of \verb{$enqueue} for details).}
+
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
@@ -423,8 +437,10 @@ queue. If the dependent task fails then this task will be
 removed from the queue. Dependencies are applied to all
 tasks added to the queue.}
 
-\item{\code{timeout}}{Optional timeout, in seconds, after which an
-error will be thrown if the task has not completed.}
+\item{\code{collect_timeout}}{Optional timeout, in seconds, after which an
+error will be thrown if all tasks have not completed. If given  as
+\code{0}, then we return a handle that can be used to check for tasks
+using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
 completion.}
@@ -455,8 +471,9 @@ be copied over rather than using their names if possible.
   envir = parent.frame(),
   queue = NULL,
   separate_process = FALSE,
+  task_timeout = NULL,
   depends_on = NULL,
-  timeout = Inf,
+  collect_timeout = Inf,
   time_poll = NULL,
   progress = NULL
 )}\if{html}{\out{</div>}}
@@ -484,6 +501,9 @@ details).}
 run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
+\item{\code{task_timeout}}{Optionally, a maximum allowed running time, in
+seconds (see the \code{timeout} argument of \verb{$enqueue} for details).}
+
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
@@ -491,10 +511,10 @@ queue. If the dependent task fails then this task will be
 removed from the queue. Dependencies are applied to all
 tasks added to the queue.}
 
-\item{\code{timeout}}{Optional timeout, in seconds, after which an
-error will be thrown if the task has not completed. If a
-timeout is given as \code{0}, then we return a handle that can be used
-to check for tasks using \code{bulk_wait}}
+\item{\code{collect_timeout}}{Optional timeout, in seconds, after which an
+error will be thrown if all tasks have not completed. If given  as
+\code{0}, then we return a handle that can be used to check for tasks
+using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
 completion.}
@@ -526,8 +546,9 @@ should feel intuitive.
   envir = parent.frame(),
   queue = NULL,
   separate_process = FALSE,
+  task_timeout = NULL,
   depends_on = NULL,
-  timeout = Inf,
+  collect_timeout = Inf,
   time_poll = NULL,
   progress = NULL
 )}\if{html}{\out{</div>}}
@@ -557,6 +578,9 @@ details).}
 run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
+\item{\code{task_timeout}}{Optionally, a maximum allowed running time, in
+seconds (see the \code{timeout} argument of \verb{$enqueue} for details).}
+
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
@@ -564,8 +588,10 @@ queue. If the dependent task fails then this task will be
 removed from the queue. Dependencies are applied to all
 tasks added to the queue.}
 
-\item{\code{timeout}}{Optional timeout, in seconds, after which an
-error will be thrown if the task has not completed.}
+\item{\code{collect_timeout}}{Optional timeout, in seconds, after which an
+error will be thrown if all tasks have not completed. If given  as
+\code{0}, then we return a handle that can be used to check for tasks
+using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
 completion.}
@@ -596,8 +622,9 @@ be copied over rather than using their names if possible.
   envir = parent.frame(),
   queue = NULL,
   separate_process = FALSE,
+  task_timeout = NULL,
   depends_on = NULL,
-  timeout = Inf,
+  collect_timeout = Inf,
   time_poll = NULL,
   progress = NULL
 )}\if{html}{\out{</div>}}
@@ -627,6 +654,9 @@ details).}
 run in a separate process on the worker (see \verb{$enqueue} for
 details).}
 
+\item{\code{task_timeout}}{Optionally, a maximum allowed running time, in
+seconds (see the \code{timeout} argument of \verb{$enqueue} for details).}
+
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
@@ -634,8 +664,10 @@ queue. If the dependent task fails then this task will be
 removed from the queue. Dependencies are applied to all
 tasks added to the queue.}
 
-\item{\code{timeout}}{Optional timeout, in seconds, after which an
-error will be thrown if the task has not completed.}
+\item{\code{collect_timeout}}{Optional timeout, in seconds, after which an
+error will be thrown if all tasks have not completed. If given  as
+\code{0}, then we return a handle that can be used to check for tasks
+using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
 completion.}

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -178,6 +178,7 @@ test_that("Cope with dying subprocess task", {
   tools::pskill(pid_sub)
   wait_status(t, obj, status = TASK_RUNNING)
   expect_equal(obj$task_status(t), set_names(TASK_DIED, t))
+  expect_equal(obj$task_result(t), worker_task_failed(TASK_DIED))
 
   log <- obj$worker_log_tail(wid, Inf)
   expect_equal(log$command,


### PR DESCRIPTION
This will be used by orderly.server; only works for tasks sent to a different process, but that's fine for our use there.