### PR TITLE
mrc-2369: control over exported variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.3.0
+Version: 0.3.1
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.3.1
+
+* Direct control over environment export for `$enqueue()` with new argument `export` (mrc-2369)
+
 # rrq 0.2.19
 
 * Add new `enqueue_bulk` method (previously deleted in 0.2.0) (mrc-2261)

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -52,7 +52,7 @@ rrq_bulk_prepare_lapply <- function(db, x, fun, dots, envir) {
     dat$expr[2L] <- x
     object_to_bin(dat)
   }
-  dat <- expression_prepare(template, envir, NULL, db,
+  dat <- expression_prepare(template, envir, db,
                             function_value = if (is.null(fun$name)) fun$value)
   lapply(x, rewrite, dat)
 }
@@ -70,7 +70,7 @@ rrq_bulk_prepare_call <- function(db, x, fun, dots, envir) {
   template <- as.call(c(list(fun$name), args, dots))
   idx <- seq_len(len) + 1L
 
-  dat <- expression_prepare(template, envir, NULL, db,
+  dat <- expression_prepare(template, envir, db,
                             function_value = if (is.null(fun$name)) fun$value)
   rewrite <- function(x) {
     dat$expr[idx] <- x

--- a/R/utils_assert.R
+++ b/R/utils_assert.R
@@ -95,3 +95,13 @@ assert_valid_timeout <- function(x, name = deparse(substitute(x))) {
     stop(sprintf("'%s' must be positive", name))
   }
 }
+
+
+assert_named <- function(x, unique = FALSE, name = deparse(substitute(x))) {
+  if (is.null(names(x))) {
+    stop(sprintf("'%s' must be named", name), call. = FALSE)
+  }
+  if (unique && any(duplicated(names(x)))) {
+    stop(sprintf("'%s' must have unique names", name), call. = FALSE)
+  }
+}

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -273,7 +273,8 @@ Queue an expression
   separate_process = FALSE,
   timeout = NULL,
   at_front = FALSE,
-  depends_on = NULL
+  depends_on = NULL,
+  export = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -318,6 +319,17 @@ completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
 queue. If the dependent task fails then this task will be
 removed from the queue.}
+
+\item{\code{export}}{Optionally a list of variables to export for the
+calculation. If given then no automatic analysis of the
+expression is done. It should be either a named list (name
+being the variable name, value being the value) or a
+character vector of variables that can be found immediately
+within \code{envir}. Use this where you have already done analysis
+of the expression (e.g., with the future package / globals)
+or where you want to avoid moving large objects through Redis
+that will be available on the remote workers due to how you
+have configured your worker environment.}
 }
 \if{html}{\out{</div>}}
 }
@@ -336,7 +348,8 @@ Queue an expression
   separate_process = FALSE,
   timeout = NULL,
   at_front = FALSE,
-  depends_on = NULL
+  depends_on = NULL,
+  export = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -378,6 +391,9 @@ completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
 queue. If the dependent task fails then this task will be
 removed from the queue.}
+
+\item{\code{export}}{Optionally a list of variables to export for the
+calculation. See \verb{$enqueue} for details.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -86,6 +86,19 @@ test_that("export variables", {
 })
 
 
+test_that("export variables", {
+  db <- storr::storr_environment()
+  e <- list2env(list(a = 1, b = 2), parent = baseenv())
+  res <- expression_prepare(quote(sin(a) + cos(b)), e, db,
+                            export = list(a = 10))
+  h <- db$hash_object(10)
+  expect_equal(res$expr, quote(sin(a) + cos(b)))
+  expect_equal(res$objects, c(a = h))
+  expect_equal(db$list(), h)
+  expect_equal(db$get(h), 10)
+})
+
+
 test_that("restore locals", {
   e <- new.env()
   db <- storr::storr_environment()

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -39,6 +39,12 @@ test_that("assertions", {
   expect_silent(assert_valid_timeout(1))
 
   expect_error(assert_is(1, "R6"), "must inherit from R6")
+
+  expect_silent(assert_named(list(a = 1)))
+  expect_error(assert_named(list(a = 1, a = 2), TRUE),
+               "must have unique names")
+  expect_error(assert_named(list(1, 2)),
+               "must be named")
 })
 
 


### PR DESCRIPTION
This PR adds support for explicitly listing variables copied over with an expression.

This is required to support future where the analysis of variables is already done, and the "user" in this case specifies name/value pairs needed for the remote calculation.

At the same time this tidies up some unneeded/unexposed complication in the expression analysis code

~Rebase on #39 once it's merged.~

