### PR TITLE
mrc-2392: Always allow blocking wait for task

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.3.1
+Version: 0.3.2
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.3.2
+
+* All tasks get a key that can be checked with a blocking wait (mrc-2392)
+
 # rrq 0.3.1
 
 * Direct control over environment export for `$enqueue()` with new argument `export` (mrc-2369)

--- a/R/keys.R
+++ b/R/keys.R
@@ -34,6 +34,8 @@ rrq_keys_common <- function(queue_id) {
        task_timeout   = sprintf("%s:task:timeout",   queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
+       ## This is the key where we store the extra complete key we
+       ## might push to at.
        task_complete  = sprintf("%s:task:complete",  queue_id),
        task_cancel    = sprintf("%s:task:cancel",    queue_id),
 
@@ -68,9 +70,9 @@ rrq_key_queue <- function(queue, name) {
   sprintf("%s:queue:%s", queue, name %||% QUEUE_DEFAULT)
 }
 
-## Randomly generated keys:
-rrq_key_task_complete <- function(queue) {
-  sprintf("%s:tasks:complete:%s", queue, ids::random_id())
+## (Potentially) randomly generated keys:
+rrq_key_task_complete <- function(queue, id = NULL) {
+  sprintf("%s:tasks:complete:%s", queue, id %||% ids::random_id())
 }
 
 rrq_key_worker_alive <- function(queue_id) {

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -899,9 +899,9 @@ rrq_controller_ <- R6::R6Class(
     ##'    system signals, which requires that the worker is on the same
     ##'    machine as the controller.
     worker_stop = function(worker_ids = NULL, type = "message",
-                           timeout = 0, time_poll = 1, progress = NULL) {
+                           timeout = 0, time_poll = 0.05, progress = NULL) {
       worker_stop(self$con, self$keys, worker_ids, type,
-                   timeout, time_poll, progress)
+                  timeout, time_poll, progress)
     },
 
     ##' @description Detects exited workers through a lapsed heartbeat
@@ -1054,7 +1054,7 @@ rrq_controller_ <- R6::R6Class(
     ##'   progress bar if in an interactive session.
     message_get_response = function(message_id, worker_ids = NULL, named = TRUE,
                                     delete = FALSE, timeout = 0,
-                                    time_poll = 1, progress = NULL) {
+                                    time_poll = 0.05, progress = NULL) {
       message_get_response(self$con, self$keys, message_id, worker_ids, named,
                            delete, timeout, time_poll, progress)
     },
@@ -1099,7 +1099,7 @@ rrq_controller_ <- R6::R6Class(
     ##'   progress bar if in an interactive session.
     message_send_and_wait = function(command, args = NULL, worker_ids = NULL,
                                      named = TRUE, delete = TRUE, timeout = 600,
-                                     time_poll = 1, progress = NULL) {
+                                     time_poll = 0.05, progress = NULL) {
       message_send_and_wait(self$con, self$keys, command, args, worker_ids,
                             named, delete, timeout, time_poll, progress)
     }
@@ -1464,7 +1464,7 @@ worker_delete_exited <- function(con, keys, worker_ids = NULL) {
 }
 
 worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
-                        timeout = 0, time_poll = NULL, progress = NULL) {
+                        timeout = 0, time_poll = 0.1, progress = NULL) {
   type <- match.arg(type, c("message", "kill", "kill_local"))
   if (is.null(worker_ids)) {
     worker_ids <- worker_list(con, keys)
@@ -1478,7 +1478,6 @@ worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
     if (timeout > 0L) {
       message_get_response(con, keys, message_id, worker_ids,
                            delete = FALSE, timeout = timeout,
-                           time_poll = time_poll,
                            progress = progress)
     }
   } else if (type == "kill") {

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1478,6 +1478,7 @@ worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
     if (timeout > 0L) {
       message_get_response(con, keys, message_id, worker_ids,
                            delete = FALSE, timeout = timeout,
+                           time_poll = time_poll,
                            progress = progress)
     }
   } else if (type == "kill") {

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -141,6 +141,7 @@ worker_run_task_cleanup <- function(worker, status, value) {
     redis$HSET(keys$task_status,    task_id,  status),
     redis$HSET(keys$worker_status,  name,     WORKER_IDLE),
     redis$HDEL(keys$worker_task,    name),
+    redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
     if (!is.null(key_complete)) {
       redis$RPUSH(key_complete, task_id)
     },

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -268,7 +268,6 @@ Queue an expression
 \if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue(
   expr,
   envir = parent.frame(),
-  key_complete = NULL,
   queue = NULL,
   separate_process = FALSE,
   timeout = NULL,
@@ -287,10 +286,6 @@ Queue an expression
 locally. This will be used to copy across any dependent variables.
 For example, if your expression is \code{sum(1 + a)}, we will also send
 the value of \code{a} to the worker along with the expression.}
-
-\item{\code{key_complete}}{The name of a Redis key to write to once the
-task is complete. You can use this with \verb{$task_wait} to efficiently
-wait for the task to complete (i.e., without using a busy loop).}
 
 \item{\code{queue}}{The queue to add the task to; if not specified the
 "default" queue (which all workers listen to) will be
@@ -343,7 +338,6 @@ Queue an expression
 \if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_(
   expr,
   envir = parent.frame(),
-  key_complete = NULL,
   queue = NULL,
   separate_process = FALSE,
   timeout = NULL,
@@ -364,11 +358,6 @@ directly (e.g., \code{bquote(log(.(x)), list(x = 10))}}
 locally. This will be used to copy across any dependent variables.
 For example, if your expression is \code{sum(1 + a)}, we will also send
 the value of \code{a} to the worker along with the expression.}
-
-\item{\code{key_complete}}{The name of a Redis key to write to once the
-task is complete. You can use this in conjunction with something
-like \code{BLPOP} to wait until a task is complete without a busy (sleep)
-loop.}
 
 \item{\code{queue}}{The queue to add the task to; if not specified the
 "default" queue (which all workers listen to) will be
@@ -416,7 +405,7 @@ equivalent to using \verb{$enqueue()} over each element in the list.
   task_timeout = NULL,
   depends_on = NULL,
   collect_timeout = Inf,
-  time_poll = NULL,
+  time_poll = 1,
   progress = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -459,7 +448,7 @@ error will be thrown if all tasks have not completed. If given  as
 using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion.}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
@@ -490,7 +479,7 @@ be copied over rather than using their names if possible.
   task_timeout = NULL,
   depends_on = NULL,
   collect_timeout = Inf,
-  time_poll = NULL,
+  time_poll = 1,
   progress = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -533,7 +522,7 @@ error will be thrown if all tasks have not completed. If given  as
 using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion.}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
@@ -565,7 +554,7 @@ should feel intuitive.
   task_timeout = NULL,
   depends_on = NULL,
   collect_timeout = Inf,
-  time_poll = NULL,
+  time_poll = 1,
   progress = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -610,7 +599,7 @@ error will be thrown if all tasks have not completed. If given  as
 using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion.}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
@@ -641,7 +630,7 @@ be copied over rather than using their names if possible.
   task_timeout = NULL,
   depends_on = NULL,
   collect_timeout = Inf,
-  time_poll = NULL,
+  time_poll = 1,
   progress = NULL
 )}\if{html}{\out{</div>}}
 }
@@ -686,7 +675,7 @@ error will be thrown if all tasks have not completed. If given  as
 using \code{bulk_wait}}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion.}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
@@ -702,7 +691,7 @@ progress bar if in an interactive session.}
 \subsection{Method \code{bulk_wait()}}{
 Wait for a group of tasks
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$bulk_wait(x, timeout = Inf, time_poll = NULL, progress = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$bulk_wait(x, timeout = Inf, time_poll = 1, progress = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -714,7 +703,7 @@ Wait for a group of tasks
 error will be thrown if the task has not completed.}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion.}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
@@ -912,9 +901,8 @@ efficient way of doing this for a group of tasks.
 \if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_wait(
   task_id,
   timeout = Inf,
-  time_poll = NULL,
-  progress = NULL,
-  key_complete = NULL
+  time_poll = 1,
+  progress = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -926,35 +914,22 @@ efficient way of doing this for a group of tasks.
 \item{\code{timeout}}{Optional timeout, in seconds, after which an
 error will be thrown if the task has not completed.}
 
-\item{\code{time_poll}}{Optional time with which to "poll" for
-completion. The default and behaviour depend on \code{key_complete} -
-see the details section.}
+\item{\code{time_poll}}{Optional time with which to "poll" for completion.
+By default this will be 1 second; this is the time that each
+request for a completed task may block for (however, if the task
+is finished before this, the actual time waited for will be less).
+Increasing this will reduce the responsiveness of your R session
+to interrupting, but will cause slightly less network load.
+Values less than 1s are not currently supported as this requires
+a very recent Redis server.}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
 global option \code{rrq.progress}, and if that is unset display a
 progress bar if in an interactive session.}
-
-\item{\code{key_complete}}{Optional key used when \code{enqueing} the tasks
-that will be written to on completion.}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Details}{
-The polling behaviour depends on \code{key_complete}. If
-\code{key_complete} is \code{NULL} then we use a busy-loop, sleeping for
-\code{time_poll} seconds between polls of Redis. As such, the smaller
-the \code{time_poll} the faster you will get your result, as it may
-be delayed by up to \code{time_poll}, but the heavier the network and
-Redis load (the default is 0.05s). Alternatively, if
-\code{key_complete} is given then your task will be returned as soon
-as it is written into Redis, and \code{time_poll} is the time between
-subsequent calls to the Redis function that enables
-this. Shorter values of \code{time_poll} then make R more responsive
-to being interrupted and longer values reduce network load (the
-default is 1s)
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-tasks_wait"></a>}}
@@ -967,9 +942,8 @@ this is roughly equivalent to \code{tasks_result}.
 \if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$tasks_wait(
   task_ids,
   timeout = Inf,
-  time_poll = NULL,
-  progress = NULL,
-  key_complete = NULL
+  time_poll = 1,
+  progress = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -982,17 +956,12 @@ this is roughly equivalent to \code{tasks_result}.
 error will be thrown if the task has not completed.}
 
 \item{\code{time_poll}}{Optional time with which to "poll" for
-completion. The default and behaviour depend on \code{key_complete} -
-see the details section of \verb{$task_wait}}
+completion (default is 1s, see \verb{$task_wait()} for details)}
 
 \item{\code{progress}}{Optional logical indicating if a progress bar
 should be displayed. If \code{NULL} we fall back on the value of the
 global option \code{rrq.progress}, and if that is unset display a
 progress bar if in an interactive session.}
-
-\item{\code{key_complete}}{Optional key used when \code{enqueing} the tasks
-that will be written to on completion. If used, then all tasks
-must share the same completion key.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -143,7 +143,7 @@ test_that("task_overview", {
 })
 
 
-test_that("wait for tasks without key", {
+test_that("wait for tasks", {
   obj <- test_rrq("myfuns.R")
   wid <- test_worker_spawn(obj)
 
@@ -158,32 +158,13 @@ test_that("wait for tasks without key", {
   t4 <- obj$enqueue(slowdouble(0.1))
   res <- obj$tasks_wait(c(t3, t4))
   expect_equal(res, set_names(list(0.2, 0.2), c(t3, t4)))
-})
-
-
-test_that("wait for tasks with key", {
-  obj <- test_rrq("myfuns.R")
-  k1 <- rrq_key_task_complete(obj$queue_id)
-  t1 <- obj$enqueue(1 + 1, key_complete = k1)
-  t2 <- obj$enqueue(2 + 2, key_complete = k1)
-
-  wid <- test_worker_spawn(obj)
 
   expect_error(
-    obj$tasks_wait(c(t1, t2), key_complete = k1, time_poll = 0.1),
+    obj$tasks_wait(c(t1, t2), time_poll = 0.1),
     "time_poll must be integer like")
   expect_error(
-    obj$tasks_wait(c(t1, t2), key_complete = k1, time_poll = -1),
-    "time_poll cannot be less than 1 if using key_complete")
-  res <- obj$tasks_wait(c(t1, t2), key_complete = k1)
-  expect_equal(res, set_names(list(2, 4), c(t1, t2)))
-
-  ## Slightly slower jobs:
-  k2 <- rrq_key_task_complete(obj$queue_id)
-  t3 <- obj$enqueue(slowdouble(0.1), key_complete = k2)
-  t4 <- obj$enqueue(slowdouble(0.1), key_complete = k2)
-  res <- obj$tasks_wait(c(t3, t4), key_complete = k2)
-  expect_equal(res, set_names(list(0.2, 0.2), c(t3, t4)))
+    obj$tasks_wait(c(t1, t2), time_poll = -1),
+    "time_poll cannot be less than 1")
 })
 
 
@@ -198,19 +179,6 @@ test_that("task delete", {
   expect_setequal(obj$task_list(), c(t2, t3))
   obj$task_delete(c(t2, t3))
   expect_setequal(obj$task_list(), character(0))
-})
-
-
-test_that("wait for tasks on a key", {
-  obj <- test_rrq("myfuns.R")
-  wid <- test_worker_spawn(obj)
-  key <- rrq_key_task_complete(obj$queue_id)
-
-  id <- obj$enqueue(sin(1), key_complete = key)
-  res <- obj$task_wait(id, 1, key_complete = NULL, progress = FALSE)
-  expect_equal(obj$con$EXISTS(key), 1)
-  expect_equal(obj$task_wait(id, key_complete = key), sin(1))
-  expect_equal(obj$con$EXISTS(key), 0)
 })
 
 


### PR DESCRIPTION
This PR eliminates the need for a "busy wait" for tasks to complete by making every task get a list that can be used with `BLPOP`. This should reduce the chattiness of the system and make returning tasks slightly faster.

~Merge after #43~