### PR TITLE
Port to use testthat v3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^scripts$
 ^docker$
 ^\.github$
+^\.hadolint\.yml$

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+ignored:
+  # Affects Dockerfile.worker - version not found as it's an arg
+  - DL3006
+  # https://github.com/hadolint/hadolint/wiki/DL3008
+  # I can't imagine ever wanting this
+  - DL3008

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.4.1
+Version: 0.4.2
 Author: Rich FitzJohn
 Maintainer: Rich FitzJohn <rich.fitzjohn@gmail.com>
 Description: Simple Redis queue in R.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,3 +26,4 @@ RoxygenNote: 7.1.1
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Language: en-GB
+Config/testthat/edition: 3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,20 @@
 FROM rocker/r-ver:3.6.1
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install --no-install-recommends \
         libhiredis-dev \
-        libssl-dev
+        libssl-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY docker/bin /usr/local/bin/
 RUN sed  -i'' '/mran.microsoft.com/d' /usr/local/lib/R/etc/Rprofile.site && \
-        Rscript -e 'install.packages("docopt")'
-
-RUN install_packages --repo=https://mrc-ide.github.io/drat \
-        R6 \
-        docopt \
-        ids \
-        progress \
-        redux
+        Rscript -e 'install.packages("docopt")' && \
+        install_packages --repo=https://mrc-ide.github.io/drat \
+            R6 \
+            docopt \
+            ids \
+            progress \
+            redux
 
 COPY . /src
 RUN R CMD INSTALL /src && \

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -29,7 +29,9 @@ wait_status <- function(t, obj, timeout = 2, time_poll = 0.05,
     if (all(obj$task_status(t) != status)) {
       return()
     }
-    message(".")
+    if (!testthat::is_testing()) {
+      message(".")
+    }
     Sys.sleep(time_poll)
   }
   stop(sprintf("Did not change status from %s in time", status))
@@ -43,7 +45,9 @@ wait_worker_status <- function(w, obj, status, timeout = 2,
     if (all(obj$worker_status(w) != status)) {
       return()
     }
-    message(".")
+    if (!testthat::is_testing()) {
+      message(".")
+    }
     Sys.sleep(time_poll)
   }
   stop(sprintf("Did not change status from %s in time", status))
@@ -66,7 +70,7 @@ test_store <- function(..., prefix = NULL) {
 }
 
 
-test_rrq <- function(sources = NULL, root = tempfile()) {
+test_rrq <- function(sources = NULL, root = tempfile(), verbose = FALSE) {
   skip_if_no_redis()
   Sys.setenv(R_TESTS = "")
 
@@ -88,7 +92,7 @@ test_rrq <- function(sources = NULL, root = tempfile()) {
   environment(create) <- create_env
 
   obj <- rrq_controller(name)
-  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
+  obj$worker_config_save("localhost", time_poll = 1, verbose = verbose)
   obj$envir(create)
   reg.finalizer(obj, function(e) obj$destroy())
   obj
@@ -131,6 +135,13 @@ skip_on_windows <- function() {
 
 r6_private <- function(x) {
   x[[".__enclos_env__"]]$private
+}
+
+
+## Functions change type from function to closure at 4.1, preventing
+## use of expect_type
+expect_is_function <- function(x) {
+  testthat::expect_true(is.function(x))
 }
 
 

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -88,7 +88,7 @@ test_rrq <- function(sources = NULL, root = tempfile()) {
   environment(create) <- create_env
 
   obj <- rrq_controller(name)
-  obj$worker_config_save("localhost", time_poll = 1)
+  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
   obj$envir(create)
   reg.finalizer(obj, function(e) obj$destroy())
   obj
@@ -98,7 +98,7 @@ test_rrq <- function(sources = NULL, root = tempfile()) {
 test_worker_spawn <- function(obj, ..., timeout = 10) {
   skip_on_cran()
   skip_on_windows()
-  worker_spawn(obj, ..., timeout = timeout)
+  suppressMessages(worker_spawn(obj, ..., timeout = timeout))
 }
 
 

--- a/tests/testthat/test-bulk-support.R
+++ b/tests/testthat/test-bulk-support.R
@@ -1,5 +1,3 @@
-context("bulk support")
-
 test_that("match_fun_envir can find functions by name", {
   add <- function(a, b) a + b
   expected <- list(name = NULL, value = add)

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -1,5 +1,3 @@
-context("configure")
-
 test_that("Can set and retrieve a configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -1,5 +1,3 @@
-context("expression")
-
 test_that("eval safely - simple case", {
   e <- list2env(list(a = 1, b = 2), parent = baseenv())
   expect_equal(
@@ -18,10 +16,10 @@ test_that("eval safely - error", {
 
   res <- expression_eval_safely(f1(FALSE), e)
   expect_false(res$success)
-  expect_is(res$value, "rrq_task_error")
-  expect_is(res$value, "error")
+  expect_s3_class(res$value, "rrq_task_error")
+  expect_s3_class(res$value, "error")
   expect_equal(res$value$message, "some deep error")
-  expect_is(res$value$trace, "character")
+  expect_s3_class(res$value$trace, "character")
   expect_match(res$value$trace, "f3(x)", fixed = TRUE, all = FALSE)
 })
 

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -19,7 +19,7 @@ test_that("eval safely - error", {
   expect_s3_class(res$value, "rrq_task_error")
   expect_s3_class(res$value, "error")
   expect_equal(res$value$message, "some deep error")
-  expect_s3_class(res$value$trace, "character")
+  expect_type(res$value$trace, "character")
   expect_match(res$value$trace, "f3(x)", fixed = TRUE, all = FALSE)
 })
 

--- a/tests/testthat/test-message.R
+++ b/tests/testthat/test-message.R
@@ -1,13 +1,10 @@
-context("messaging")
-
-
 test_that("TIMEOUT_SET causes worker exit on idle worker", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
   obj$message_send("TIMEOUT_SET", 0)
   w$step(TRUE)
   expect_equal(r6_private(w)$timeout, 0)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
   expect_lt(r6_private(w)$timer(), 0)
   expect_error(w$step(TRUE), "TIMEOUT", class = "rrq_worker_stop")
 })
@@ -32,7 +29,7 @@ test_that("TIMEOUT_SET with null clears a timer", {
   obj$message_send("TIMEOUT_SET", 1)
   w$step(TRUE)
   expect_equal(r6_private(w)$timeout, 1)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
   obj$message_send("TIMEOUT_SET", NULL)
   w$step(TRUE)
   expect_null(r6_private(w)$timeout)
@@ -59,14 +56,14 @@ test_that("TIMEOUT_GET returns time remaining", {
 
   obj$message_send("TIMEOUT_SET", 100)
   w$step(TRUE)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
 
   Sys.sleep(0.1)
   id <- obj$message_send("TIMEOUT_GET")
   w$step(TRUE)
 
   response <- obj$message_get_response(id, w$name)
-  expect_is(response, "list")
+  expect_type(response, "list")
   expect_equal(names(response), w$name)
   expect_equal(response[[1]][["timeout"]], 100)
   expect_lt(response[[1]][["remaining"]], 100)
@@ -94,7 +91,7 @@ test_that("TIMEOUT_GET restores a timer", {
   expect_null(r6_private(w)$timer)
 
   w$step(TRUE)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
 })
 
 
@@ -102,8 +99,8 @@ test_that("message response getting", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
   id <- obj$message_send("PING")
-  expect_is(id, "character")
-  expect_is(redux::redis_time_to_r(id), "POSIXct")
+  expect_type(id, "character")
+  expect_s3_class(redux::redis_time_to_r(id), "POSIXct")
 
   ## Not yet a response:
   expect_equal(obj$message_has_response(id, w$name), set_names(FALSE, w$name))
@@ -381,7 +378,7 @@ test_that("send and wait", {
   expect_equal(res[[1]], "PONG")
   expect_equal(names(res), wid[[1]])
   id <- attr(res, "message_id")
-  expect_is(id, "character")
+  expect_type(id, "character")
   expect_equal(obj$message_get_response(id, wid[[1]]),
                set_names(list("PONG"), wid[[1]]))
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -1,6 +1,3 @@
-context("migrate")
-
-
 test_that("Can migrate storage", {
   skip_if_no_redis()
   dat <- readRDS("migrate/0.3.1.rds")

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -15,9 +15,11 @@ test_that("Can migrate storage", {
     rrq_worker_from_config(dat$queue_id, "localhost"),
     "rrq database needs migrating; please run")
 
-  expect_message(
-    rrq_migrate(dat$queue_id),
-    "Migrating rrq database")
+  res <- evaluate_promise(
+    rrq_migrate(dat$queue_id))
+  expect_match(res$messages, "Migrating rrq database", all = FALSE)
+  expect_match(res$messages, "Updated 4 / 5 task expressions", all = FALSE)
+  expect_match(res$messages, "Updated 5 task results", all = FALSE)
 
   expect_message(
     rrq_migrate(dat$queue_id),

--- a/tests/testthat/test-object-store.R
+++ b/tests/testthat/test-object-store.R
@@ -1,5 +1,3 @@
-context("object_store")
-
 test_that("Fast noop operations behave as expected", {
   s <- test_store()
 

--- a/tests/testthat/test-redis.R
+++ b/tests/testthat/test-redis.R
@@ -1,5 +1,3 @@
-context("redis utilities")
-
 test_that("scan expire", {
   con <- test_hiredis()
 

--- a/tests/testthat/test-rrq-progress.R
+++ b/tests/testthat/test-rrq-progress.R
@@ -1,5 +1,3 @@
-context("progress")
-
 test_that("basic use", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -1,5 +1,3 @@
-context("workers")
-
 test_that("clean up exited workers", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
@@ -103,14 +101,14 @@ test_that("Timer is recreated after task run", {
   w <- test_worker_blocking(obj)
   obj$message_send("TIMEOUT_SET", 10)
   w$step(TRUE)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
 
   obj$enqueue(sin(1))
   w$step(TRUE)
   expect_null(r6_private(w)$timer)
 
   w$step(TRUE)
-  expect_is(r6_private(w)$timer, "function")
+  expect_type(r6_private(w)$timer, "function")
 })
 
 

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -101,14 +101,14 @@ test_that("Timer is recreated after task run", {
   w <- test_worker_blocking(obj)
   obj$message_send("TIMEOUT_SET", 10)
   w$step(TRUE)
-  expect_type(r6_private(w)$timer, "function")
+  expect_is_function(r6_private(w)$timer)
 
   obj$enqueue(sin(1))
   w$step(TRUE)
   expect_null(r6_private(w)$timer)
 
   w$step(TRUE)
-  expect_type(r6_private(w)$timer, "function")
+  expect_is_function(r6_private(w)$timer)
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -245,7 +245,7 @@ test_that("change environment", {
   expect_equal(r6_private(w)$envir$x, 1)
 
   obj$envir(NULL)
-  expect_message(w$step(TRUE), "REFRESH")
+  w$step(TRUE)
   expect_equal(ls(r6_private(w)$envir), character(0))
 })
 
@@ -343,7 +343,7 @@ test_that("get task data errors appropriately if task is missing", {
 
 test_that("a worker will pick up tasks from the priority queue", {
   obj <- test_rrq("myfuns.R")
-  obj$worker_config_save("localhost", queue = c("a", "b"))
+  obj$worker_config_save("localhost", queue = c("a", "b"), verbose = FALSE)
   w <- test_worker_blocking(obj)
 
   t1 <- obj$enqueue(sin(1))

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -889,6 +889,7 @@ test_that("can offload storage", {
   rrq_configure(name, store_max_size = 100, offload_path = path)
 
   obj <- rrq_controller(name)
+  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
   a <- 10
   b <- runif(20)
   t <- obj$enqueue(sum(b) / a)
@@ -922,6 +923,7 @@ test_that("offload storage in result", {
   rrq_configure(name, store_max_size = 100, offload_path = path)
 
   obj <- rrq_controller(name)
+  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
   t <- obj$enqueue(rep(1, 100))
 
   w <- test_worker_blocking(obj)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -1,5 +1,3 @@
-context("time")
-
 test_that("time_checker", {
   t <- time_checker(100)
   expect_gt(t(), 0)
@@ -40,8 +38,8 @@ test_that("progress - vector and with timeout", {
   p <- progress_timeout(10, show = TRUE, label = "things", timeout = 5,
                         width = 50, force = TRUE)
   expect_setequal(names(p), c("tick", "terminate"))
-  expect_is(p$tick, "function")
-  expect_is(p$terminate, "function")
+  expect_type(p$tick, "function")
+  expect_type(p$terminate, "function")
 
   res1 <- evaluate_promise(p$tick(1))
   expect_equal(res1$result, FALSE)
@@ -88,8 +86,8 @@ test_that("progress - don't show", {
   p <- progress_timeout(1, show = FALSE, label = "things", timeout = Inf,
                         width = 50, force = TRUE)
   expect_setequal(names(p), c("tick", "terminate"))
-  expect_is(p$tick, "function")
-  expect_is(p$terminate, "function")
+  expect_type(p$tick, "function")
+  expect_type(p$terminate, "function")
   expect_silent(p$tick())
   expect_false(p$tick())
   expect_silent(p$terminate())

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -38,8 +38,8 @@ test_that("progress - vector and with timeout", {
   p <- progress_timeout(10, show = TRUE, label = "things", timeout = 5,
                         width = 50, force = TRUE)
   expect_setequal(names(p), c("tick", "terminate"))
-  expect_type(p$tick, "function")
-  expect_type(p$terminate, "function")
+  expect_is_function(p$tick)
+  expect_is_function(p$terminate)
 
   res1 <- evaluate_promise(p$tick(1))
   expect_equal(res1$result, FALSE)
@@ -86,8 +86,8 @@ test_that("progress - don't show", {
   p <- progress_timeout(1, show = FALSE, label = "things", timeout = Inf,
                         width = 50, force = TRUE)
   expect_setequal(names(p), c("tick", "terminate"))
-  expect_type(p$tick, "function")
-  expect_type(p$terminate, "function")
+  expect_is_function(p$tick)
+  expect_is_function(p$terminate)
   expect_silent(p$tick())
   expect_false(p$tick())
   expect_silent(p$terminate())

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,3 @@
-context("utils")
-
 test_that("rstrip", {
   expect_equal(rstrip("  "), "")
   expect_equal(rstrip("a  "), "a")

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -4,7 +4,7 @@ test_that("rrq_default configuration", {
   obj <- test_rrq()
   expect_equal(obj$worker_config_list(), "localhost")
   expect_equal(obj$worker_config_read("localhost"),
-               list(time_poll = 1, verbose = TRUE))
+               list(time_poll = 1, verbose = FALSE))
 })
 
 
@@ -12,7 +12,8 @@ test_that("create short-lived worker", {
   obj <- test_rrq()
 
   key <- "stop_immediately"
-  cfg <- obj$worker_config_save(key, timeout = 0, time_poll = 1)
+  cfg <- obj$worker_config_save(key, timeout = 0, time_poll = 1,
+                                verbose = FALSE)
 
   ## Local:
   msg1 <- capture_messages(
@@ -81,7 +82,7 @@ test_that("worker timeout", {
   obj <- test_rrq("myfuns.R")
 
   t <- as.integer(runif(1, min = 100, max = 10000))
-  res <- obj$worker_config_save("localhost", timeout = t)
+  res <- obj$worker_config_save("localhost", timeout = t, verbose = FALSE)
   expect_equal(res$timeout, t)
 
   w <- test_worker_blocking(obj)
@@ -98,7 +99,7 @@ test_that("worker timeout", {
 
 test_that("infinite timeout", {
   obj <- test_rrq("myfuns.R")
-  obj$worker_config_save("infinite", timeout = Inf)
+  obj$worker_config_save("infinite", timeout = Inf, verbose = FALSE)
 
   w <- test_worker_blocking(obj, worker_config = "infinite")
   expect_equal(r6_private(w)$timeout, Inf)

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -1,5 +1,3 @@
-context("worker_config")
-
 test_that("rrq_default configuration", {
   ## (this is actually the *test* default configuration, which is
   ## possibly not what is wanted)
@@ -26,9 +24,9 @@ test_that("create short-lived worker", {
   ## Remote:
   logs <- tempfile()
   wid <- test_worker_spawn(obj, worker_config = key, logdir = logs)
-  expect_is(wid, "character")
+  expect_type(wid, "character")
   log <- obj$worker_log_tail(wid, Inf)
-  expect_is(log, "data.frame")
+  expect_s3_class(log, "data.frame")
   expect_true(nrow(log) >= 1)
 
   remaining <- time_checker(3)

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -13,7 +13,7 @@ test_that("create short-lived worker", {
 
   key <- "stop_immediately"
   cfg <- obj$worker_config_save(key, timeout = 0, time_poll = 1,
-                                verbose = FALSE)
+                                verbose = TRUE)
 
   ## Local:
   msg1 <- capture_messages(

--- a/tests/testthat/test-worker-spawn.R
+++ b/tests/testthat/test-worker-spawn.R
@@ -14,12 +14,14 @@ test_that("Don't wait", {
 
 
 test_that("failed spawn", {
+  skip_on_windows()
+
   root <- tempfile()
-  obj <- test_rrq("myfuns.R", root)
+  obj <- test_rrq("myfuns.R", root, verbose = TRUE)
   unlink(file.path(root, "myfuns.R"))
 
   dat <- evaluate_promise(
-    try(test_worker_spawn(obj, 2, timeout = 2),
+    try(worker_spawn(obj, 2, timeout = 2),
         silent = TRUE))
 
   expect_s3_class(dat$result, "try-error")
@@ -34,7 +36,7 @@ test_that("failed spawn", {
 
 
 test_that("read worker process log", {
-  obj <- test_rrq()
+  obj <- test_rrq(verbose = TRUE)
   wid <- test_worker_spawn(obj, 1)
   obj$message_send_and_wait("STOP")
   txt <- obj$worker_process_log(wid)

--- a/tests/testthat/test-worker-spawn.R
+++ b/tests/testthat/test-worker-spawn.R
@@ -1,11 +1,9 @@
-context("worker spawn")
-
 test_that("Don't wait", {
   obj <- test_rrq()
   res <- test_worker_spawn(obj, 4, timeout = 0)
-  expect_is(res$names, "character")
+  expect_type(res$names, "character")
   expect_match(res$names, "_[0-9]+$")
-  expect_is(res$key_alive, "character")
+  expect_type(res$key_alive, "character")
 
   ans <- worker_wait(obj, res$key_alive, timeout = 10, time_poll = 1)
   expect_setequal(ans, res$names)
@@ -24,7 +22,7 @@ test_that("failed spawn", {
     try(test_worker_spawn(obj, 2, timeout = 2),
         silent = TRUE))
 
-  expect_is(dat$result, "try-error")
+  expect_s3_class(dat$result, "try-error")
   expect_match(dat$messages, "2 / 2 workers not identified in time",
                all = FALSE, fixed = TRUE)
   expect_match(dat$output, "Log files recovered for 2 workers",
@@ -40,7 +38,7 @@ test_that("read worker process log", {
   wid <- test_worker_spawn(obj, 1)
   obj$message_send_and_wait("STOP")
   txt <- obj$worker_process_log(wid)
-  expect_is(txt, "character")
+  expect_type(txt, "character")
   expect_match(txt, "ALIVE", all = FALSE)
 })
 

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -1,5 +1,3 @@
-context("fault tolerance")
-
 test_that("heartbeat", {
   skip_if_not_installed("callr")
   obj <- test_rrq()

--- a/tests/testthat/test-zzz-heartbeat.R
+++ b/tests/testthat/test-zzz-heartbeat.R
@@ -1,5 +1,3 @@
-context("heartbeat")
-
 test_that("basic interaction with heartbeat works", {
   skip_if_no_redis()
   config <- redux::redis_config()
@@ -7,8 +5,8 @@ test_that("basic interaction with heartbeat works", {
   period <- 1
   expire <- 2
   obj <- heartbeat$new(key, period, expire = expire, start = FALSE)
-  expect_is(obj, "heartbeat")
-  expect_is(obj, "R6")
+  expect_s3_class(obj, "heartbeat")
+  expect_s3_class(obj, "R6")
 
   con <- test_hiredis()
   expect_equal(con$EXISTS(key), 0)


### PR DESCRIPTION
Maintenance PR to port to testthat 3e (see https://testthat.r-lib.org/articles/third-edition.html)