### PR TITLE
Allow resetting identical configuration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
 Suggests:
     callr (>= 3.7.0),
     knitr,
+    markdown,
     mockery,
     processx,
     rmarkdown,

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -25,13 +25,21 @@ test_that("Can't set a conflicting configuration", {
   name <- sprintf("rrq:%s", ids::random_id())
   config <- rrq_configure(name, store_max_size = 100)
   expect_error(
-    rrq_configure(name, store_max_size = 100),
+    rrq_configure(name, store_max_size = 101),
     "Can't set configuration for queue '.+' as it already exists")
   expect_error(
     rrq_configure(name, store_max_size = Inf, offload_path = tempfile()),
     "Can't set configuration for queue '.+' as it already exists")
   expect_equal(rrq_configure_read(test_hiredis(), rrq_keys_common(name)),
                config)
+})
+
+
+test_that("Can set an identical configuration", {
+  name <- sprintf("rrq:%s", ids::random_id())
+  config1 <- rrq_configure(name, store_max_size = 100)
+  config2 <- rrq_configure(name, store_max_size = 100)
+  expect_identical(config1, config2)
 })
 
 


### PR DESCRIPTION
This just tripped me and @RaphaelS1 up; if identical configurations are set, that should be a no-op so that scripts don't need to guess if it's needed or not.