### PR TITLE
Use R6 constructors directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.4.5
+Version: 0.5.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/envir.R
+++ b/R/envir.R
@@ -1,10 +1,10 @@
 ##' Helper function for creating a worker environment. This function
 ##' exists to create a function suitable for passing to the `envir`
-##' method of [rrq::rrq_controller()] for the common case where the
+##' method of [`rrq::rrq_controller`] for the common case where the
 ##' worker should source some R scripts and/or load some packages on
 ##' startup. This is a convenience wrapper around defining your own
 ##' function for use with the `envir` method of
-##' [rrq::rrq_controller()], which covers the most simple case. If you
+##' [`rrq::rrq_controller`], which covers the most simple case. If you
 ##' need more flexibility you should write your own.
 ##'
 ##' @title Create simple worker environments
@@ -16,7 +16,7 @@
 ##'   you might read large data objects here too.
 ##'
 ##' @return A function suitable for passing to the `$envir()` method
-##'   of [rrq::rrq_controller()]
+##'   of [`rrq::rrq_controller`]
 ##'
 ##' @export
 rrq_envir <- function(packages = NULL, sources = NULL) {

--- a/R/heartbeat_impl.R
+++ b/R/heartbeat_impl.R
@@ -183,7 +183,7 @@ heartbeat <- R6::R6Class(
 
 ##' Send a kill signal (typically `SIGTERM`) to terminate a process
 ##' that is running a heartbeat. This is used by
-##' [rrq::rrq_controller()] in order to tear down workers, even if
+##' [`rrq::rrq_controller`] in order to tear down workers, even if
 ##' they are processing a task. When a heartbeat process is created,
 ##' in its main loop it will listen for requests to kill via this
 ##' function and will forward them to the worker. This is primarily

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -2,12 +2,6 @@
 ##'
 ##' @title rrq queue controller
 ##'
-##' @param queue_id An identifier for the queue.  This will prefix all
-##'   keys in redis, so a prefix might be useful here depending on
-##'   your use case (e.g. \code{rrq:<user>:<id>})
-##'
-##' @param con A redis connection
-##'
 ##' @section Task lifecycle:
 ##'
 ##' * A task is queued with `$enqueue()`, at which point it becomes `PENDING`
@@ -116,14 +110,7 @@
 ##' ```
 ##'
 ##' @export
-rrq_controller <- function(queue_id, con = redux::hiredis()) {
-  assert_scalar_character(queue_id)
-  assert_is(con, "redis_api")
-  rrq_controller_$new(queue_id, con)
-}
-
-##' @rdname rrq_controller
-rrq_controller_ <- R6::R6Class(
+rrq_controller <- R6::R6Class(
   "rrq_controller",
   cloneable = FALSE,
 
@@ -137,10 +124,17 @@ rrq_controller_ <- R6::R6Class(
     ##' @field keys Internally used keys
     keys = NULL,
 
-    ##' @description Constructor (called by `rrq_controller()`)
-    ##' @param queue_id An identifier for the queue
-    ##' @param con A redis connection
-    initialize = function(queue_id, con) {
+    ##' @description Constructor
+    ##' @param queue_id An identifier for the queue.  This will prefix all
+    ##'   keys in redis, so a prefix might be useful here depending on
+    ##'   your use case (e.g. \code{rrq:<user>:<id>})
+    ##' @param con A redis connection. The default tries to create a redis
+    ##'   connection using default ports, or environment variables set as in
+    ##'   [redux::hiredis()]
+    initialize = function(queue_id, con = redux::hiredis()) {
+      assert_scalar_character(queue_id)
+      assert_is(con, "redis_api")
+
       self$con <- con
       self$queue_id <- queue_id
       self$keys <- rrq_keys(self$queue_id)

--- a/README.Rmd
+++ b/README.Rmd
@@ -3,6 +3,7 @@
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
+  error = FALSE,
   comment = "#>",
   fig.path = "man/figures/README-",
   out.width = "100%"
@@ -25,7 +26,7 @@ Task queues for R, implemented using Redis.
 Create an `rrq_controller` object
 
 ```{r}
-obj <- rrq::rrq_controller("rrq:readme")
+obj <- rrq::rrq_controller$new("rrq:readme")
 ```
 
 Submit work to the queue:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-output: github_document
----
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 
@@ -23,7 +19,7 @@ Create an `rrq_controller` object
 
 
 ```r
-obj <- rrq::rrq_controller("rrq:readme")
+obj <- rrq::rrq_controller$new("rrq:readme")
 ```
 
 Submit work to the queue:
@@ -32,7 +28,7 @@ Submit work to the queue:
 ```r
 t <- obj$enqueue(runif(10))
 t
-#> [1] "53a2e58afc836ff75a0abab53f75e85f"
+#> [1] "6a368aa506da1aabcd264ca859fa3322"
 ```
 
 Query task process:
@@ -40,7 +36,7 @@ Query task process:
 
 ```r
 obj$task_status(t)
-#> 53a2e58afc836ff75a0abab53f75e85f
+#> 6a368aa506da1aabcd264ca859fa3322
 #>                        "PENDING"
 ```
 
@@ -49,8 +45,8 @@ Run tasks on workers in the background
 
 ```r
 rrq::worker_spawn(obj)
-#> Spawning 1 worker with prefix nearby_ammonite
-#> [1] "nearby_ammonite_1"
+#> Spawning 1 worker with prefix endocrinous_anemonecrab
+#> [1] "endocrinous_anemonecrab_1"
 ```
 
 Collect task results when complete
@@ -58,8 +54,17 @@ Collect task results when complete
 
 ```r
 obj$task_wait(t)
-#>  [1] 0.9499495 0.3754099 0.4028146 0.6498432 0.1732155 0.6069491 0.6379786
-#>  [8] 0.8193451 0.1927368 0.8221052
+#>  [1] 0.6429454 0.3498470 0.2804653 0.2975355 0.1308821 0.1520124 0.3212029
+#>  [8] 0.1526649 0.1589430 0.3306704
+```
+
+Or try and retrieve them regardless of if they are complete
+
+
+```r
+obj$task_result(t)
+#>  [1] 0.6429454 0.3498470 0.2804653 0.2975355 0.1308821 0.1520124 0.3212029
+#>  [8] 0.1526649 0.1589430 0.3306704
 ```
 
 Query what workers have done
@@ -67,10 +72,14 @@ Query what workers have done
 
 ```r
 obj$worker_log_tail(n = Inf)
-#>           worker_id       time       command                          message
-#> 1 nearby_ammonite_1 1623142169         ALIVE
-#> 2 nearby_ammonite_1 1623142169    TASK_START 53a2e58afc836ff75a0abab53f75e85f
-#> 3 nearby_ammonite_1 1623142169 TASK_COMPLETE 53a2e58afc836ff75a0abab53f75e85f
+#>                   worker_id       time       command
+#> 1 endocrinous_anemonecrab_1 1629120683         ALIVE
+#> 2 endocrinous_anemonecrab_1 1629120683    TASK_START
+#> 3 endocrinous_anemonecrab_1 1629120683 TASK_COMPLETE
+#>                            message
+#> 1
+#> 2 6a368aa506da1aabcd264ca859fa3322
+#> 3 6a368aa506da1aabcd264ca859fa3322
 ```
 
 For more information, see `vignette("rrq")`

--- a/extra/benchmark.Rmd
+++ b/extra/benchmark.Rmd
@@ -20,7 +20,7 @@ A simple benchmark attempt:
 ``` {r }
 root <- tempfile()
 context <- context::context_load(context::context_save(root))
-obj <- rrq::rrq_controller(context, redux::hiredis())
+obj <- rrq::rrq_controller$new(context, redux::hiredis())
 
 wid <- rrq::worker_spawn(obj, 2L, logdir = tempdir())
 ```

--- a/man/heartbeat_kill.Rd
+++ b/man/heartbeat_kill.Rd
@@ -17,7 +17,7 @@ heartbeat_kill(con, key, signal = tools::SIGTERM)
 \description{
 Send a kill signal (typically \code{SIGTERM}) to terminate a process
 that is running a heartbeat. This is used by
-\code{\link[=rrq_controller]{rrq_controller()}} in order to tear down workers, even if
+\code{\link{rrq_controller}} in order to tear down workers, even if
 they are processing a task. When a heartbeat process is created,
 in its main loop it will listen for requests to kill via this
 function and will forward them to the worker. This is primarily

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -2,20 +2,30 @@
 % Please edit documentation in R/rrq_controller.R
 \name{rrq_controller}
 \alias{rrq_controller}
-\alias{rrq_controller_}
 \title{rrq queue controller}
-\usage{
-rrq_controller(queue_id, con = redux::hiredis())
-}
-\arguments{
-\item{queue_id}{An identifier for the queue.  This will prefix all
-keys in redis, so a prefix might be useful here depending on
-your use case (e.g. \code{rrq:<user>:<id>})}
-
-\item{con}{A redis connection}
-}
 \description{
+rrq queue controller
+
+rrq queue controller
+}
+\details{
 A queue controller.  Use this to interact with a queue/cluster.
+
+The \code{type} parameter indicates the strategy used to stop
+workers, and interacts with other parameters. The strategies used by
+the different values are:
+\itemize{
+\item \code{message}, in which case a \code{STOP} message will be sent to the
+worker, which they will receive after finishing any currently
+running task (if \code{RUNNING}; \code{IDLE} workers will stop immediately).
+\item \code{kill}, in which case a kill signal will be sent via the heartbeat
+(if the worker is using one). This will kill the worker even if
+is currently working on a task, eventually leaving that task with
+a status of \code{DIED}.
+\item \code{kill_local}, in which case a kill signal is sent using operating
+system signals, which requires that the worker is on the same
+machine as the controller.
+}
 }
 \section{Task lifecycle}{
 
@@ -128,71 +138,75 @@ ans <- obj$lapply_(1:10, quote(log), base = quote(b))
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{
-\item \href{#method-new}{\code{rrq_controller_$new()}}
-\item \href{#method-destroy}{\code{rrq_controller_$destroy()}}
-\item \href{#method-envir}{\code{rrq_controller_$envir()}}
-\item \href{#method-enqueue}{\code{rrq_controller_$enqueue()}}
-\item \href{#method-enqueue_}{\code{rrq_controller_$enqueue_()}}
-\item \href{#method-lapply}{\code{rrq_controller_$lapply()}}
-\item \href{#method-lapply_}{\code{rrq_controller_$lapply_()}}
-\item \href{#method-enqueue_bulk}{\code{rrq_controller_$enqueue_bulk()}}
-\item \href{#method-enqueue_bulk_}{\code{rrq_controller_$enqueue_bulk_()}}
-\item \href{#method-bulk_wait}{\code{rrq_controller_$bulk_wait()}}
-\item \href{#method-task_list}{\code{rrq_controller_$task_list()}}
-\item \href{#method-task_exists}{\code{rrq_controller_$task_exists()}}
-\item \href{#method-task_status}{\code{rrq_controller_$task_status()}}
-\item \href{#method-task_progress}{\code{rrq_controller_$task_progress()}}
-\item \href{#method-task_overview}{\code{rrq_controller_$task_overview()}}
-\item \href{#method-task_position}{\code{rrq_controller_$task_position()}}
-\item \href{#method-task_preceeding}{\code{rrq_controller_$task_preceeding()}}
-\item \href{#method-task_result}{\code{rrq_controller_$task_result()}}
-\item \href{#method-tasks_result}{\code{rrq_controller_$tasks_result()}}
-\item \href{#method-task_wait}{\code{rrq_controller_$task_wait()}}
-\item \href{#method-tasks_wait}{\code{rrq_controller_$tasks_wait()}}
-\item \href{#method-task_delete}{\code{rrq_controller_$task_delete()}}
-\item \href{#method-task_cancel}{\code{rrq_controller_$task_cancel()}}
-\item \href{#method-task_data}{\code{rrq_controller_$task_data()}}
-\item \href{#method-queue_length}{\code{rrq_controller_$queue_length()}}
-\item \href{#method-queue_list}{\code{rrq_controller_$queue_list()}}
-\item \href{#method-queue_remove}{\code{rrq_controller_$queue_remove()}}
-\item \href{#method-deferred_list}{\code{rrq_controller_$deferred_list()}}
-\item \href{#method-worker_len}{\code{rrq_controller_$worker_len()}}
-\item \href{#method-worker_list}{\code{rrq_controller_$worker_list()}}
-\item \href{#method-worker_list_exited}{\code{rrq_controller_$worker_list_exited()}}
-\item \href{#method-worker_info}{\code{rrq_controller_$worker_info()}}
-\item \href{#method-worker_status}{\code{rrq_controller_$worker_status()}}
-\item \href{#method-worker_log_tail}{\code{rrq_controller_$worker_log_tail()}}
-\item \href{#method-worker_task_id}{\code{rrq_controller_$worker_task_id()}}
-\item \href{#method-worker_delete_exited}{\code{rrq_controller_$worker_delete_exited()}}
-\item \href{#method-worker_stop}{\code{rrq_controller_$worker_stop()}}
-\item \href{#method-worker_detect_exited}{\code{rrq_controller_$worker_detect_exited()}}
-\item \href{#method-worker_process_log}{\code{rrq_controller_$worker_process_log()}}
-\item \href{#method-worker_config_save}{\code{rrq_controller_$worker_config_save()}}
-\item \href{#method-worker_config_list}{\code{rrq_controller_$worker_config_list()}}
-\item \href{#method-worker_config_read}{\code{rrq_controller_$worker_config_read()}}
-\item \href{#method-worker_load}{\code{rrq_controller_$worker_load()}}
-\item \href{#method-message_send}{\code{rrq_controller_$message_send()}}
-\item \href{#method-message_has_response}{\code{rrq_controller_$message_has_response()}}
-\item \href{#method-message_get_response}{\code{rrq_controller_$message_get_response()}}
-\item \href{#method-message_response_ids}{\code{rrq_controller_$message_response_ids()}}
-\item \href{#method-message_send_and_wait}{\code{rrq_controller_$message_send_and_wait()}}
+\item \href{#method-new}{\code{rrq_controller$new()}}
+\item \href{#method-destroy}{\code{rrq_controller$destroy()}}
+\item \href{#method-envir}{\code{rrq_controller$envir()}}
+\item \href{#method-enqueue}{\code{rrq_controller$enqueue()}}
+\item \href{#method-enqueue_}{\code{rrq_controller$enqueue_()}}
+\item \href{#method-lapply}{\code{rrq_controller$lapply()}}
+\item \href{#method-lapply_}{\code{rrq_controller$lapply_()}}
+\item \href{#method-enqueue_bulk}{\code{rrq_controller$enqueue_bulk()}}
+\item \href{#method-enqueue_bulk_}{\code{rrq_controller$enqueue_bulk_()}}
+\item \href{#method-bulk_wait}{\code{rrq_controller$bulk_wait()}}
+\item \href{#method-task_list}{\code{rrq_controller$task_list()}}
+\item \href{#method-task_exists}{\code{rrq_controller$task_exists()}}
+\item \href{#method-task_status}{\code{rrq_controller$task_status()}}
+\item \href{#method-task_progress}{\code{rrq_controller$task_progress()}}
+\item \href{#method-task_overview}{\code{rrq_controller$task_overview()}}
+\item \href{#method-task_position}{\code{rrq_controller$task_position()}}
+\item \href{#method-task_preceeding}{\code{rrq_controller$task_preceeding()}}
+\item \href{#method-task_result}{\code{rrq_controller$task_result()}}
+\item \href{#method-tasks_result}{\code{rrq_controller$tasks_result()}}
+\item \href{#method-task_wait}{\code{rrq_controller$task_wait()}}
+\item \href{#method-tasks_wait}{\code{rrq_controller$tasks_wait()}}
+\item \href{#method-task_delete}{\code{rrq_controller$task_delete()}}
+\item \href{#method-task_cancel}{\code{rrq_controller$task_cancel()}}
+\item \href{#method-task_data}{\code{rrq_controller$task_data()}}
+\item \href{#method-queue_length}{\code{rrq_controller$queue_length()}}
+\item \href{#method-queue_list}{\code{rrq_controller$queue_list()}}
+\item \href{#method-queue_remove}{\code{rrq_controller$queue_remove()}}
+\item \href{#method-deferred_list}{\code{rrq_controller$deferred_list()}}
+\item \href{#method-worker_len}{\code{rrq_controller$worker_len()}}
+\item \href{#method-worker_list}{\code{rrq_controller$worker_list()}}
+\item \href{#method-worker_list_exited}{\code{rrq_controller$worker_list_exited()}}
+\item \href{#method-worker_info}{\code{rrq_controller$worker_info()}}
+\item \href{#method-worker_status}{\code{rrq_controller$worker_status()}}
+\item \href{#method-worker_log_tail}{\code{rrq_controller$worker_log_tail()}}
+\item \href{#method-worker_task_id}{\code{rrq_controller$worker_task_id()}}
+\item \href{#method-worker_delete_exited}{\code{rrq_controller$worker_delete_exited()}}
+\item \href{#method-worker_stop}{\code{rrq_controller$worker_stop()}}
+\item \href{#method-worker_detect_exited}{\code{rrq_controller$worker_detect_exited()}}
+\item \href{#method-worker_process_log}{\code{rrq_controller$worker_process_log()}}
+\item \href{#method-worker_config_save}{\code{rrq_controller$worker_config_save()}}
+\item \href{#method-worker_config_list}{\code{rrq_controller$worker_config_list()}}
+\item \href{#method-worker_config_read}{\code{rrq_controller$worker_config_read()}}
+\item \href{#method-worker_load}{\code{rrq_controller$worker_load()}}
+\item \href{#method-message_send}{\code{rrq_controller$message_send()}}
+\item \href{#method-message_has_response}{\code{rrq_controller$message_has_response()}}
+\item \href{#method-message_get_response}{\code{rrq_controller$message_get_response()}}
+\item \href{#method-message_response_ids}{\code{rrq_controller$message_response_ids()}}
+\item \href{#method-message_send_and_wait}{\code{rrq_controller$message_send_and_wait()}}
 }
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
 \if{latex}{\out{\hypertarget{method-new}{}}}
 \subsection{Method \code{new()}}{
-Constructor (called by \code{rrq_controller()})
+Constructor
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$new(queue_id, con)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$new(queue_id, con = redux::hiredis())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{queue_id}}{An identifier for the queue}
+\item{\code{queue_id}}{An identifier for the queue.  This will prefix all
+keys in redis, so a prefix might be useful here depending on
+your use case (e.g. \code{rrq:<user>:<id>})}
 
-\item{\code{con}}{A redis connection}
+\item{\code{con}}{A redis connection. The default tries to create a redis
+connection using default ports, or environment variables set as in
+\code{\link[redux:hiredis]{redux::hiredis()}}}
 }
 \if{html}{\out{</div>}}
 }
@@ -205,7 +219,7 @@ Entirely destroy a queue, by deleting all keys
 associated with it from the Redis database. This is a very
 destructive action and cannot be undone.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$destroy(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$destroy(
   delete = TRUE,
   worker_stop_type = "message",
   worker_stop_timeout = 0
@@ -242,7 +256,7 @@ Register a function to create an environment when
 creating a worker. When a worker starts, they will run this
 function.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$envir(create, notify = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$envir(create, notify = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -266,7 +280,7 @@ message to all workers to update their environment.}
 \subsection{Method \code{enqueue()}}{
 Queue an expression
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$enqueue(
   expr,
   envir = parent.frame(),
   queue = NULL,
@@ -336,7 +350,7 @@ have configured your worker environment.}
 \subsection{Method \code{enqueue_()}}{
 Queue an expression
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$enqueue_(
   expr,
   envir = parent.frame(),
   queue = NULL,
@@ -395,7 +409,7 @@ calculation. See \verb{$enqueue} for details.}
 Apply a function over a list of data. This is
 equivalent to using \verb{$enqueue()} over each element in the list.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$lapply(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$lapply(
   x,
   fun,
   ...,
@@ -469,7 +483,7 @@ With this version, both are passed by value; this may create more
 overhead on the redis server as the values of the variables will
 be copied over rather than using their names if possible.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$lapply_(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$lapply_(
   x,
   fun,
   ...,
@@ -544,7 +558,7 @@ is provided. Rather than \verb{$lapply()} which applies \code{fun} to each
 element of \code{x}, \verb{enqueue_bulk will apply over each row of }x\verb{, spreading the columms out as arguments. If you have a function }f(a, b)\verb{and a [data.frame] with columns}a\code{and}b` this
 should feel intuitive.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_bulk(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$enqueue_bulk(
   x,
   fun,
   ...,
@@ -620,7 +634,7 @@ With this version, both are passed by value; this may create more
 overhead on the redis server as the values of the variables will
 be copied over rather than using their names if possible.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$enqueue_bulk_(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$enqueue_bulk_(
   x,
   fun,
   ...,
@@ -692,7 +706,7 @@ progress bar if in an interactive session.}
 \subsection{Method \code{bulk_wait()}}{
 Wait for a group of tasks
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$bulk_wait(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$bulk_wait(
   x,
   timeout = Inf,
   time_poll = 1,
@@ -730,7 +744,7 @@ to prevent build-up of lots of task information in Redis.}
 \subsection{Method \code{task_list()}}{
 List ids of all tasks known to this rrq controller
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_list()}\if{html}{\out{</div>}}
 }
 
 }
@@ -741,7 +755,7 @@ List ids of all tasks known to this rrq controller
 Test if task with id \code{task_ids} is known to this
 rrq controller
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_exists(task_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_exists(task_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -760,7 +774,7 @@ Return a character vector of task statuses. The name
 of each element corresponds to a task id, and the value will be
 one of the possible statuses ("PENDING", "COMPLETE", etc).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_status(task_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_status(task_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -781,7 +795,7 @@ Retrieve task progress, if set. This will be \code{NULL}
 if progress has never been registered, otherwise whatever value
 was set - can be an arbitrary R object.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_progress(task_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_progress(task_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -800,7 +814,7 @@ Provide a high level overview of task statuses
 for a set of task ids, being the count in major categories of
 \code{PENDING}, \code{RUNNING}, \code{COMPLETE} and \code{ERROR}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_overview(task_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_overview(task_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -819,7 +833,7 @@ all task ids known to this rrq controller is used.}
 \subsection{Method \code{task_position()}}{
 Find the position of one or more tasks in the queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_position(task_ids, missing = 0L, queue = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_position(task_ids, missing = 0L, queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -847,7 +861,7 @@ If the task is missing from the queue this will return NULL. If
 the task is next in the queue this will return an empty character
 vector.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_preceeding(task_id, queue = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_preceeding(task_id, queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -870,7 +884,7 @@ for a method for efficiently getting multiple results at once).
 Returns the value of running the task if it is complete, and an
 error otherwise.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_result(task_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_result(task_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -888,7 +902,7 @@ error otherwise.
 Get the results of a group of tasks, returning them as a
 list.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$tasks_result(task_ids)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$tasks_result(task_ids)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -909,7 +923,7 @@ when completed. If the task has already completed this is
 roughly equivalent to \code{task_result}. See \verb{$tasks_wait} for an
 efficient way of doing this for a group of tasks.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_wait(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_wait(
   task_id,
   timeout = Inf,
   time_poll = 1,
@@ -950,7 +964,7 @@ Poll for a group of tasks to complete, returning the
 result as list when completed. If the tasks have already completed
 this is roughly equivalent to \code{tasks_result}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$tasks_wait(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$tasks_wait(
   task_ids,
   timeout = Inf,
   time_poll = 1,
@@ -983,7 +997,7 @@ progress bar if in an interactive session.}
 \subsection{Method \code{task_delete()}}{
 Delete one or more tasks
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_delete(task_ids, check = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_delete(task_ids, check = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1008,7 +1022,7 @@ it was set to run in a separate process (i.e., queued with
 \code{separate_process = TRUE}). Dependent tasks will be marked as
 impossible.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_cancel(task_id, wait = TRUE, delete = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_cancel(task_id, wait = TRUE, delete = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1036,7 +1050,7 @@ error with task_id and status e.g. Task 123 is not running (MISSING)
 Fetch internal data about a task from Redis
 (expert use only).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$task_data(task_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_data(task_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1054,7 +1068,7 @@ Fetch internal data about a task from Redis
 Returns the number of tasks in the queue (waiting for
 an available worker).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_length(queue = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$queue_length(queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1072,7 +1086,7 @@ an available worker).
 \subsection{Method \code{queue_list()}}{
 Returns the keys in the task queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_list(queue = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$queue_list(queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1090,7 +1104,7 @@ Returns the keys in the task queue.
 \subsection{Method \code{queue_remove()}}{
 Remove task ids from a queue.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$queue_remove(task_ids, queue = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$queue_remove(task_ids, queue = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1112,7 +1126,7 @@ Return deferred tasks and what they are waiting on.
 Note this is in an arbitrary order, tasks will be added to the
 queue as their dependencies are satisfied.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$deferred_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$deferred_list()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1122,7 +1136,7 @@ queue as their dependencies are satisfied.
 \subsection{Method \code{worker_len()}}{
 Returns the number of active workers
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_len()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_len()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1132,7 +1146,7 @@ Returns the number of active workers
 \subsection{Method \code{worker_list()}}{
 Returns the ids of active workers
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_list()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1142,7 +1156,7 @@ Returns the ids of active workers
 \subsection{Method \code{worker_list_exited()}}{
 Returns the ids of workers known to have exited
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_list_exited()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_list_exited()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1153,7 +1167,7 @@ Returns the ids of workers known to have exited
 Returns a list of information about active
 workers (or exited workers if \code{worker_ids} includes them).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_info(worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_info(worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1171,7 +1185,7 @@ all active workers are used.}
 \subsection{Method \code{worker_status()}}{
 Returns a character vector of current worker statuses
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_status(worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_status(worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1194,7 +1208,7 @@ event happened; see \link[redux:redis_time]{redux::redis_time} to convert this t
 time), \code{command} (the worker command) and \code{message} (the message
 corresponding to that command).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_log_tail(worker_ids = NULL, n = 1)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_log_tail(worker_ids = NULL, n = 1)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1216,7 +1230,7 @@ last entry. Use \code{Inf} or \code{0} to indicate that you want all log entries
 Returns the task id that each worker is working on,
 if any.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_task_id(worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_task_id(worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1234,7 +1248,7 @@ all active workers are used.}
 \subsection{Method \code{worker_delete_exited()}}{
 Cleans up workers known to have exited
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_delete_exited(worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_delete_exited(worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1252,7 +1266,7 @@ rrq looks for exited workers.}
 \subsection{Method \code{worker_stop()}}{
 Stop workers.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_stop(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_stop(
   worker_ids = NULL,
   type = "message",
   timeout = 0,
@@ -1287,24 +1301,6 @@ progress bar if in an interactive session.}
 }
 \if{html}{\out{</div>}}
 }
-\subsection{Details}{
-The \code{type} parameter indicates the strategy used to stop
-workers, and interacts with other parameters. The strategies used by
-the different values are:
-\itemize{
-\item \code{message}, in which case a \code{STOP} message will be sent to the
-worker, which they will receive after finishing any currently
-running task (if \code{RUNNING}; \code{IDLE} workers will stop immediately).
-\item \code{kill}, in which case a kill signal will be sent via the heartbeat
-(if the worker is using one). This will kill the worker even if
-is currently working on a task, eventually leaving that task with
-a status of \code{DIED}.
-\item \code{kill_local}, in which case a kill signal is sent using operating
-system signals, which requires that the worker is on the same
-machine as the controller.
-}
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-worker_detect_exited"></a>}}
@@ -1312,7 +1308,7 @@ machine as the controller.
 \subsection{Method \code{worker_detect_exited()}}{
 Detects exited workers through a lapsed heartbeat
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_detect_exited()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_detect_exited()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1326,7 +1322,7 @@ storage) as the controller. This will generally behave for
 workers started with \link{worker_spawn} but may require significant
 care otherwise.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_process_log(worker_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_process_log(worker_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1345,7 +1341,7 @@ Save a worker configuration, which can be used to
 start workers with a set of options with the cli. These
 correspond to arguments to \link{rrq_worker}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_config_save(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_config_save(
   name,
   time_poll = NULL,
   timeout = NULL,
@@ -1403,7 +1399,7 @@ be thrown).}
 Return names of worker configurations saved by
 \verb{$worker_config_save}
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_config_list()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_config_list()}\if{html}{\out{</div>}}
 }
 
 }
@@ -1414,7 +1410,7 @@ Return names of worker configurations saved by
 Return the value of a of worker configuration saved by
 \verb{$worker_config_save}
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_config_read(name)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_config_read(name)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1434,7 +1430,7 @@ interface may change).}
 \if{latex}{\out{\hypertarget{method-worker_load}{}}}
 \subsection{Method \code{worker_load()}}{
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$worker_load(worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$worker_load(worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1454,7 +1450,7 @@ Send a message to workers. Sending a message returns
 a message id, which can be used to poll for a response with the
 other \verb{message_*} methods.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$message_send(command, args = NULL, worker_ids = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$message_send(command, args = NULL, worker_ids = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1477,7 +1473,7 @@ to. If \code{NULL} then the message will be sent to all active workers.}
 \subsection{Method \code{message_has_response()}}{
 Detect if a response is available for a message
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$message_has_response(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$message_has_response(
   message_id,
   worker_ids = NULL,
   named = TRUE
@@ -1505,7 +1501,7 @@ of workers that the message was sent to!)}
 Get response to messages, waiting until the
 message has been responded to.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$message_get_response(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$message_get_response(
   message_id,
   worker_ids = NULL,
   named = TRUE,
@@ -1555,7 +1551,7 @@ progress bar if in an interactive session.}
 Return ids for messages with responses for a
 particular worker.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$message_response_ids(worker_id)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$message_response_ids(worker_id)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1574,7 +1570,7 @@ Send a message and wait for responses.
 This is a helper function around \code{message_send} and
 \code{message_get_response}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller_$message_send_and_wait(
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$message_send_and_wait(
   command,
   args = NULL,
   worker_ids = NULL,

--- a/man/rrq_envir.Rd
+++ b/man/rrq_envir.Rd
@@ -15,15 +15,15 @@ you might read large data objects here too.}
 }
 \value{
 A function suitable for passing to the \verb{$envir()} method
-of \code{\link[=rrq_controller]{rrq_controller()}}
+of \code{\link{rrq_controller}}
 }
 \description{
 Helper function for creating a worker environment. This function
 exists to create a function suitable for passing to the \code{envir}
-method of \code{\link[=rrq_controller]{rrq_controller()}} for the common case where the
+method of \code{\link{rrq_controller}} for the common case where the
 worker should source some R scripts and/or load some packages on
 startup. This is a convenience wrapper around defining your own
 function for use with the \code{envir} method of
-\code{\link[=rrq_controller]{rrq_controller()}}, which covers the most simple case. If you
+\code{\link{rrq_controller}}, which covers the most simple case. If you
 need more flexibility you should write your own.
 }

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -91,7 +91,7 @@ test_rrq <- function(sources = NULL, root = tempfile(), verbose = FALSE) {
   }
   environment(create) <- create_env
 
-  obj <- rrq_controller(name)
+  obj <- rrq_controller$new(name)
   obj$worker_config_save("localhost", time_poll = 1, verbose = verbose)
   obj$envir(create)
   reg.finalizer(obj, function(e) obj$destroy())

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -247,7 +247,7 @@ test_that("Can offload storage for bulk tasks", {
   path <- tempfile()
   rrq_configure(name, store_max_size = 100, offload_path = path)
 
-  obj <- rrq_controller(name)
+  obj <- rrq_controller$new(name)
   obj$worker_config_save("localhost", verbose = FALSE, timeout = -1,
                          time_poll = 1, overwrite = TRUE)
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -9,7 +9,7 @@ test_that("Can migrate storage", {
   invisible(lapply(dat$data, redis_restore, con))
 
   expect_error(
-    rrq_controller(dat$queue_id),
+    rrq_controller$new(dat$queue_id),
     "rrq database needs migrating; please run")
   expect_error(
     rrq_worker_from_config(dat$queue_id, "localhost"),
@@ -25,7 +25,7 @@ test_that("Can migrate storage", {
     rrq_migrate(dat$queue_id),
     "rrq database is up-to-date")
 
-  obj <- rrq_controller(dat$queue_id)
+  obj <- rrq_controller$new(dat$queue_id)
   expect_setequal(obj$task_list(), names(dat$tasks))
 
   expect_equal(obj$tasks_result(names(dat$tasks)), dat$tasks)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -888,7 +888,7 @@ test_that("can offload storage", {
   path <- tempfile()
   rrq_configure(name, store_max_size = 100, offload_path = path)
 
-  obj <- rrq_controller(name)
+  obj <- rrq_controller$new(name)
   obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
   a <- 10
   b <- runif(20)
@@ -922,7 +922,7 @@ test_that("offload storage in result", {
   path <- tempfile()
   rrq_configure(name, store_max_size = 100, offload_path = path)
 
-  obj <- rrq_controller(name)
+  obj <- rrq_controller$new(name)
   obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
   t <- obj$enqueue(rep(1, 100))
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -151,9 +151,11 @@ test_that("wait success returns result", {
 })
 
 test_that("wait success returns error message", {
+  timeout <- if (interactive() 0.1 else 1
+  poll <- timeout / 2
   callback <- mockery::mock(stop("Failure"), cycle = TRUE)
   msg <- evaluate_promise(expect_error(
-    wait_success("my explanation", 0.1, callback, 0.05)))
+    wait_success("my explanation", timeout, callback, poll)))
   expect_equal(msg$messages, c("Failure\n", "Failure\n"))
   expect_equal(msg$result$message, "Timeout: my explanation\nFailure")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -151,7 +151,7 @@ test_that("wait success returns result", {
 })
 
 test_that("wait success returns error message", {
-  timeout <- if (interactive() 0.1 else 1
+  timeout <- if (interactive()) 0.1 else 1
   poll <- timeout / 2
   callback <- mockery::mock(stop("Failure"), cycle = TRUE)
   msg <- evaluate_promise(expect_error(

--- a/vignettes/messages.Rmd
+++ b/vignettes/messages.Rmd
@@ -18,33 +18,33 @@ vignette shows what the possible messages do.
 In order to do this, we're going to need a queue and a worker:
 
 ```r
-obj <- rrq::rrq_controller("rrq:messages")
+obj <- rrq::rrq_controller$new("rrq:messages")
 logdir <- tempfile()
 worker_id <- rrq::worker_spawn(obj, logdir = logdir)
-#> Spawning 1 worker with prefix apathetic_foal
+#> Spawning 1 worker with prefix diffident_hoatzin
 ```
 
 On startup the worker log contains:
 
 ```plain
-[2021-06-09 14:07:06] QUEUE default
-[2021-06-09 14:07:06] ENVIR new
-[2021-06-09 14:07:06] ALIVE
+[2021-08-16 14:29:19] QUEUE default
+[2021-08-16 14:29:20] ENVIR new
+[2021-08-16 14:29:20] ALIVE
                                  __
                 ______________ _/ /
       ______   / ___/ ___/ __ `/ /_____
      /_____/  / /  / /  / /_/ /_/_____/
  ______      /_/  /_/   \__, (_)   ______
 /_____/                   /_/     /_____/
-    worker:        apathetic_foal_1
-    rrq_version:   0.4.3 [LOCAL]
+    worker:        diffident_hoatzin_1
+    rrq_version:   0.5.0 [LOCAL]
     platform:      x86_64-pc-linux-gnu (64-bit)
     running:       Ubuntu 20.04.2 LTS
     hostname:      wpia-dide300
     username:      rfitzjoh
     queue:         rrq:messages:queue:default
     wd:            /home/rfitzjoh/Documents/src/rrq/vignettes_src
-    pid:           78076
+    pid:           220704
     redis_host:    127.0.0.1
     redis_port:    6379
     heartbeat_key: <not set>
@@ -86,16 +86,16 @@ The message id is going to be useful for getting responses:
 
 ```r
 message_id
-#> [1] "1623244026.408720"
+#> [1] "1629120560.49013"
 ```
 
 (this is derived from the current time, according to Redis which is
 the central reference point of time for the whole system).
 
 ```plain
-[2021-06-09 14:07:06] MESSAGE PING
+[2021-08-16 14:29:20] MESSAGE PING
 PONG
-[2021-06-09 14:07:06] RESPONSE PING
+[2021-08-16 14:29:20] RESPONSE PING
 ```
 
 The logfile prints:
@@ -109,10 +109,10 @@ We can access the same bits of information in the worker log:
 
 ```r
 obj$worker_log_tail(n = Inf)
-#>          worker_id       time  command message
-#> 1 apathetic_foal_1 1623244026    ALIVE
-#> 2 apathetic_foal_1 1623244026  MESSAGE    PING
-#> 3 apathetic_foal_1 1623244026 RESPONSE    PING
+#>             worker_id       time  command message
+#> 1 diffident_hoatzin_1 1629120560    ALIVE
+#> 2 diffident_hoatzin_1 1629120560  MESSAGE    PING
+#> 3 diffident_hoatzin_1 1629120560 RESPONSE    PING
 ```
 
 This includes the `ALIVE` message as the worker comes up.
@@ -125,8 +125,8 @@ We already know that our worker has a response, but we can ask anyway:
 
 ```r
 obj$message_has_response(message_id)
-#> apathetic_foal_1
-#>             TRUE
+#> diffident_hoatzin_1
+#>                TRUE
 ```
 
 Or inversely we can as what messages a given worker has responses for:
@@ -134,7 +134,7 @@ Or inversely we can as what messages a given worker has responses for:
 
 ```r
 obj$message_response_ids(worker_id)
-#> [1] "1623244026.408720"
+#> [1] "1629120560.49013"
 ```
 
 To fetch the responses from all workers it was sent to (always
@@ -143,7 +143,7 @@ returning a named list):
 
 ```r
 obj$message_get_response(message_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "PONG"
 ```
 
@@ -152,7 +152,7 @@ or to fetch the response from a given worker:
 
 ```r
 obj$message_get_response(message_id, worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "PONG"
 ```
 
@@ -161,7 +161,7 @@ The response can be deleted by passing `delete = TRUE` to this method:
 
 ```r
 obj$message_get_response(message_id, worker_id, delete = TRUE)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "PONG"
 ```
 
@@ -170,7 +170,7 @@ after which recalling the message will throw an error:
 
 ```r
 obj$message_get_response(message_id, worker_id)
-#> Error in message_get_response(self$con, self$keys, message_id, worker_ids, : Response missing for workers: apathetic_foal_1
+#> Error in message_get_response(self$con, self$keys, message_id, worker_ids, : Response missing for workers: diffident_hoatzin_1
 ```
 
 There is also a `timeout` argument that lets you wait until a response is
@@ -179,10 +179,10 @@ ready (as in `$task_wait()`).
 
 ```r
 obj$enqueue(Sys.sleep(2))
-#> [1] "6b0157c37642956a3f795f1fa7be7eb5"
+#> [1] "8142f2a96d2c0073070a3b71209f7e9a"
 message_id <- obj$message_send("PING")
 obj$message_get_response(message_id, worker_id, delete = TRUE, timeout = 10)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "PONG"
 ```
 
@@ -191,11 +191,11 @@ Looking at the log will show what went on here:
 
 ```r
 obj$worker_log_tail(n = 4)
-#>          worker_id       time       command                          message
-#> 1 apathetic_foal_1 1623244026    TASK_START 6b0157c37642956a3f795f1fa7be7eb5
-#> 2 apathetic_foal_1 1623244028 TASK_COMPLETE 6b0157c37642956a3f795f1fa7be7eb5
-#> 3 apathetic_foal_1 1623244028       MESSAGE                             PING
-#> 4 apathetic_foal_1 1623244028      RESPONSE                             PING
+#>             worker_id       time       command                          message
+#> 1 diffident_hoatzin_1 1629120560    TASK_START 8142f2a96d2c0073070a3b71209f7e9a
+#> 2 diffident_hoatzin_1 1629120562 TASK_COMPLETE 8142f2a96d2c0073070a3b71209f7e9a
+#> 3 diffident_hoatzin_1 1629120562       MESSAGE                             PING
+#> 4 diffident_hoatzin_1 1629120562      RESPONSE                             PING
 ```
 
 1. A task is received
@@ -208,11 +208,11 @@ completed, the response takes a while to come back.  Equivalently,
 from the worker log:
 
 ```plain
-[2021-06-09 14:07:06] TASK_START 6b0157c37642956a3f795f1fa7be7eb5
-[2021-06-09 14:07:08] TASK_COMPLETE 6b0157c37642956a3f795f1fa7be7eb5
-[2021-06-09 14:07:08] MESSAGE PING
+[2021-08-16 14:29:20] TASK_START 8142f2a96d2c0073070a3b71209f7e9a
+[2021-08-16 14:29:22] TASK_COMPLETE 8142f2a96d2c0073070a3b71209f7e9a
+[2021-08-16 14:29:22] MESSAGE PING
 PONG
-[2021-06-09 14:07:08] RESPONSE PING
+[2021-08-16 14:29:22] RESPONSE PING
 ```
 
 ## `ECHO`
@@ -225,14 +225,14 @@ response.
 ```r
 message_id <- obj$message_send("ECHO", "hello world!")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "OK"
 ```
 
 ```plain
-[2021-06-09 14:07:08] MESSAGE ECHO
+[2021-08-16 14:29:22] MESSAGE ECHO
 hello world!
-[2021-06-09 14:07:08] RESPONSE ECHO
+[2021-08-16 14:29:22] RESPONSE ECHO
 ```
 
 ## `INFO`
@@ -245,10 +245,10 @@ worker started up:
 ```r
 obj$worker_info()[[worker_id]]
 #> $worker
-#> [1] "apathetic_foal_1"
+#> [1] "diffident_hoatzin_1"
 #>
 #> $rrq_version
-#> [1] "0.4.3 [LOCAL]"
+#> [1] "0.5.0 [LOCAL]"
 #>
 #> $platform
 #> [1] "x86_64-pc-linux-gnu (64-bit)"
@@ -269,7 +269,7 @@ obj$worker_info()[[worker_id]]
 #> [1] "/home/rfitzjoh/Documents/src/rrq/vignettes_src"
 #>
 #> $pid
-#> [1] 78076
+#> [1] 220704
 #>
 #> $redis_host
 #> [1] "127.0.0.1"
@@ -291,38 +291,38 @@ field:
 
 ```r
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $apathetic_foal_1
-#> $apathetic_foal_1$worker
-#> [1] "apathetic_foal_1"
+#> $diffident_hoatzin_1
+#> $diffident_hoatzin_1$worker
+#> [1] "diffident_hoatzin_1"
 #>
-#> $apathetic_foal_1$rrq_version
-#> [1] "0.4.3 [LOCAL]"
+#> $diffident_hoatzin_1$rrq_version
+#> [1] "0.5.0 [LOCAL]"
 #>
-#> $apathetic_foal_1$platform
+#> $diffident_hoatzin_1$platform
 #> [1] "x86_64-pc-linux-gnu (64-bit)"
 #>
-#> $apathetic_foal_1$running
+#> $diffident_hoatzin_1$running
 #> [1] "Ubuntu 20.04.2 LTS"
 #>
-#> $apathetic_foal_1$hostname
+#> $diffident_hoatzin_1$hostname
 #> [1] "wpia-dide300"
 #>
-#> $apathetic_foal_1$username
+#> $diffident_hoatzin_1$username
 #> [1] "rfitzjoh"
 #>
-#> $apathetic_foal_1$queue
+#> $diffident_hoatzin_1$queue
 #> [1] "rrq:messages:queue:default"
 #>
-#> $apathetic_foal_1$wd
+#> $diffident_hoatzin_1$wd
 #> [1] "/home/rfitzjoh/Documents/src/rrq/vignettes_src"
 #>
-#> $apathetic_foal_1$pid
-#> [1] 78076
+#> $diffident_hoatzin_1$pid
+#> [1] 220704
 #>
-#> $apathetic_foal_1$redis_host
+#> $diffident_hoatzin_1$redis_host
 #> [1] "127.0.0.1"
 #>
-#> $apathetic_foal_1$redis_port
+#> $diffident_hoatzin_1$redis_port
 #> [1] 6379
 ```
 
@@ -337,7 +337,7 @@ in which queued code is evaluated in.
 ```r
 message_id <- obj$message_send("EVAL", "1 + 1")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] 2
 ```
 
@@ -353,15 +353,15 @@ The `PAUSE` / `RESUME` messages can be used to prevent workers from picking up n
 
 ```r
 obj$worker_status()
-#> apathetic_foal_1
-#>           "IDLE"
+#> diffident_hoatzin_1
+#>              "IDLE"
 message_id <- obj$message_send("PAUSE")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "OK"
 obj$worker_status()
-#> apathetic_foal_1
-#>         "PAUSED"
+#> diffident_hoatzin_1
+#>            "PAUSED"
 ```
 
 Once paused workers ignore tasks, which stay on the queue:
@@ -370,7 +370,7 @@ Once paused workers ignore tasks, which stay on the queue:
 ```r
 t <- obj$enqueue(runif(5))
 obj$task_status(t)
-#> 51290707a0aa9f8916a9037982bfa169
+#> e452cdb00b19d7c362c53fbdbdc6ddc1
 #>                        "PENDING"
 ```
 
@@ -380,10 +380,10 @@ Sending a `RESUME` message unpauses the worker:
 ```r
 message_id <- obj$message_send("RESUME")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "OK"
 obj$task_wait(t, 5)
-#> [1] 0.9253359 0.5219021 0.8085305 0.9276333 0.6785013
+#> [1] 0.5776511 0.9477248 0.8755779 0.5264372 0.7523317
 ```
 
 ## `SET_TIMEOUT` / `GET_TIMEOUT`
@@ -393,7 +393,7 @@ Workers will quit after being left idle for more than a certain time; this is th
 
 ```r
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #>   timeout remaining
 #>       Inf       Inf
 ```
@@ -403,7 +403,7 @@ We can set this to a finite value, in seconds:
 
 ```r
 obj$message_send_and_wait("TIMEOUT_SET", 600, worker_ids = worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #> [1] "OK"
 ```
 
@@ -414,14 +414,14 @@ Once set, the `TIMEOUT_GET` returns the length of time remaining before the work
 
 ```r
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #>   timeout remaining
-#>  600.0000  599.9236
+#>  600.0000  599.9454
 Sys.sleep(5)
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #>   timeout remaining
-#>  600.0000  594.8563
+#>  600.0000  594.8839
 ```
 
 One useful pattern is to send work to workers, then set the timeout to zero. This means that when work is complete they will exit (almost) immediately:
@@ -432,20 +432,20 @@ grp <- obj$lapply(1:5, function(x) {Sys.sleep(0.5); runif(x)},
                   collect_timeout = 0)
 obj$message_send("TIMEOUT_SET", 0, worker_id)
 obj$tasks_wait(grp$task_ids)
-#> $`3c4b902fdd5699b1be821b2e590b7227`
-#> [1] 0.3421876
+#> $f71bec091b2bc04ffc5c0c9b4be48c3d
+#> [1] 0.9955857
 #>
-#> $`3c165d0a392f32626e7bf27befbca88b`
-#> [1] 0.83115854 0.07525319
+#> $`3cc098b8a60c43c26b7edf7a260a8c53`
+#> [1] 0.5221255 0.5169811
 #>
-#> $`959b070bc15c07e0cd1831f95c2e8f90`
-#> [1] 0.11390606 0.06076373 0.94028717
+#> $`72107666f575bc16a3e6a6fbd0b982f4`
+#> [1] 0.34050517 0.05117652 0.50181767
 #>
-#> $`349a837ec8a9aa0233300f5bdfe63c8c`
-#> [1] 0.02231837 0.94838146 0.58987129 0.53926766
+#> $c14ce04a0fce794b3a1da3aaebe2f879
+#> [1] 0.2171280 0.3574258 0.6061184 0.8941738
 #>
-#> $`61d075c4f62bc5139dd887d50624b884`
-#> [1] 0.1103014 0.5702724 0.3199219 0.6558833 0.9898985
+#> $ab204eec9b8437916750739a68cb9720
+#> [1] 0.57544213 0.56431650 0.08574383 0.39630902 0.14331484
 ```
 
 The worker will remain idle for 60s (by default) which is the length of time that one poll for work lasts, then it will exit.
@@ -453,10 +453,10 @@ The worker will remain idle for 60s (by default) which is the length of time tha
 
 ```r
 obj$worker_status(worker_id)
-#> apathetic_foal_1
-#>           "IDLE"
+#> diffident_hoatzin_1
+#>              "IDLE"
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $apathetic_foal_1
+#> $diffident_hoatzin_1
 #>   timeout remaining
 #>         0         0
 ```

--- a/vignettes/rrq.Rmd
+++ b/vignettes/rrq.Rmd
@@ -30,10 +30,10 @@ Without any great explanation, here is the basic approach to using rrq to run a 
 
 ```r
 id <- paste0("rrq:", ids::random_id(bytes = 4))
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 ```
 
-This controller uses an "identifier" (here, `id` is rrq:5f2daa61) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
+This controller uses an "identifier" (here, `id` is rrq:a067982c) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
 
 Submit a task to the queue with the `$enqueue()` method, returning a key for that task
 
@@ -41,7 +41,7 @@ Submit a task to the queue with the `$enqueue()` method, returning a key for tha
 ```r
 t <- obj$enqueue(1 + 1)
 t
-#> [1] "ea57dd0692718d5d0057e7194635acfd"
+#> [1] "5f5d4d1add181d3c98fa436525f2ffcc"
 ```
 
 We'll also need some worker processes to carry out our tasks. Here, we'll spawn two for now (see the section below on alternatives to this)
@@ -49,8 +49,8 @@ We'll also need some worker processes to carry out our tasks. Here, we'll spawn 
 
 ```r
 rrq::worker_spawn(obj, 2)
-#> Spawning 2 workers with prefix nemophilic_stinkpot
-#> [1] "nemophilic_stinkpot_1" "nemophilic_stinkpot_2"
+#> Spawning 2 workers with prefix commiserative_rodent
+#> [1] "commiserative_rodent_1" "commiserative_rodent_2"
 ```
 
 Retrieve the result, polling if needed:
@@ -123,7 +123,7 @@ Initially the task has status `RUNNING` (it will be `PENDING` *very* briefly):
 
 ```r
 obj$task_status(t)
-#> d5a1b957d6fa4fff57d5147ee647959e
+#> 55c0da0fa52706233539d58cea2c56a0
 #>                        "RUNNING"
 ```
 
@@ -133,7 +133,7 @@ Then after a couple of seconds it will complete (we pad this out here so that it
 ```r
 Sys.sleep(3)
 obj$task_result(t)
-#> [1] 0.7784492
+#> [1] 0.5593929
 ```
 
 The basic task lifecycle is this:
@@ -150,7 +150,7 @@ Above, we slept for a few seconds in order for the task to become finished. Howe
 ```r
 t <- obj$enqueue({Sys.sleep(2); runif(1)})
 obj$task_wait(t)
-#> [1] 0.6516485
+#> [1] 0.07685814
 ```
 
 The polling interval here is 1 second by default, but if the task completes within that period it will still be returned as soon as it is complete (the interval is just the time between progress bar updates and the period where an interrupt would be caught to cancel the wait).
@@ -160,9 +160,9 @@ Once a task is complete, `$task_wait` and `$task_result` are equivalent
 
 ```r
 obj$task_wait(t)
-#> [1] 0.6516485
+#> [1] 0.07685814
 obj$task_result(t)
-#> [1] 0.6516485
+#> [1] 0.07685814
 ```
 
 ## Configuring the worker environment
@@ -203,15 +203,15 @@ By default, this will notify all running workers to update their environment. No
 
 ```r
 obj$worker_log_tail(n = 4)
-#>               worker_id       time  command message
-#> 1 nemophilic_stinkpot_1 1623244023  MESSAGE REFRESH
-#> 2 nemophilic_stinkpot_2 1623244023  MESSAGE REFRESH
-#> 3 nemophilic_stinkpot_1 1623244023    ENVIR     new
-#> 4 nemophilic_stinkpot_2 1623244023    ENVIR     new
-#> 5 nemophilic_stinkpot_1 1623244023    ENVIR  create
-#> 6 nemophilic_stinkpot_2 1623244023    ENVIR  create
-#> 7 nemophilic_stinkpot_1 1623244023 RESPONSE REFRESH
-#> 8 nemophilic_stinkpot_2 1623244023 RESPONSE REFRESH
+#>                worker_id       time  command message
+#> 1 commiserative_rodent_1 1629120552  MESSAGE REFRESH
+#> 2 commiserative_rodent_2 1629120552  MESSAGE REFRESH
+#> 3 commiserative_rodent_1 1629120552    ENVIR     new
+#> 4 commiserative_rodent_2 1629120552    ENVIR     new
+#> 5 commiserative_rodent_1 1629120552    ENVIR  create
+#> 6 commiserative_rodent_2 1629120552    ENVIR  create
+#> 7 commiserative_rodent_1 1629120552 RESPONSE REFRESH
+#> 8 commiserative_rodent_2 1629120552 RESPONSE REFRESH
 ```
 
 Now our workers have picked up our functions we can start using them:
@@ -277,7 +277,7 @@ Create an `rrq_controller` object and tell workers to read the `deps.R` file whi
 
 
 ```r
-obj <- rrq::rrq_controller(paste0("rrq:", ids::random_id(bytes = 4)))
+obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
 obj$envir(rrq::rrq_envir(sources = "deps.R"))
 source("deps.R")
 ```
@@ -301,7 +301,7 @@ The status of the first task will be `PENDING`, per usual:
 
 ```r
 obj$task_status(id)
-#> 050fa8dbd32220b1d7d93a842b8c9962
+#> c708b37c35233af42ebc5ff7cf2dbc6e
 #>                        "PENDING"
 ```
 
@@ -310,14 +310,14 @@ however, the group of tasks submitted as part of the `$lapply` call will be `DEF
 
 ```r
 obj$task_status(id_use$task_ids)
-#> eb7855c15a4141d335587d7a19a2ec2e 65f0638d4a261acc13112d6b12d9d93f
+#> a4643f65cbe9a61e7b8de845d67a59d4 e5ee67e6a65c03d03b135187d87212b0
 #>                       "DEFERRED"                       "DEFERRED"
-#> d9db40f5b7ceecd70a0f10d1d5108b38 abff381d456615bb3f12b86da45f260a
+#> d6ad45e50de4319af7b4639afd81f8e7 3a5ac2303d2ee6cf9b383b20d2c85e0f
 #>                       "DEFERRED"                       "DEFERRED"
-#> ce3d55d0d767ab507eb67ebcbeccc58f
+#> 5b0b888a2903282ec6458c3af2b76a0f
 #>                       "DEFERRED"
 obj$queue_list()
-#> [1] "050fa8dbd32220b1d7d93a842b8c9962"
+#> [1] "c708b37c35233af42ebc5ff7cf2dbc6e"
 ```
 
 obj$task_result(id_use$task_ids[[1]])
@@ -329,19 +329,19 @@ Once the first task is processed by a worker, the status changes:
 
 ```r
 obj$task_status(id)
-#> 050fa8dbd32220b1d7d93a842b8c9962
+#> c708b37c35233af42ebc5ff7cf2dbc6e
 #>                       "COMPLETE"
 obj$task_status(id_use$task_ids)
-#> eb7855c15a4141d335587d7a19a2ec2e 65f0638d4a261acc13112d6b12d9d93f
+#> a4643f65cbe9a61e7b8de845d67a59d4 e5ee67e6a65c03d03b135187d87212b0
 #>                        "PENDING"                        "PENDING"
-#> d9db40f5b7ceecd70a0f10d1d5108b38 abff381d456615bb3f12b86da45f260a
+#> d6ad45e50de4319af7b4639afd81f8e7 3a5ac2303d2ee6cf9b383b20d2c85e0f
 #>                        "PENDING"                        "PENDING"
-#> ce3d55d0d767ab507eb67ebcbeccc58f
+#> 5b0b888a2903282ec6458c3af2b76a0f
 #>                        "PENDING"
 obj$queue_list()
-#> [1] "ce3d55d0d767ab507eb67ebcbeccc58f" "eb7855c15a4141d335587d7a19a2ec2e"
-#> [3] "65f0638d4a261acc13112d6b12d9d93f" "d9db40f5b7ceecd70a0f10d1d5108b38"
-#> [5] "abff381d456615bb3f12b86da45f260a"
+#> [1] "5b0b888a2903282ec6458c3af2b76a0f" "d6ad45e50de4319af7b4639afd81f8e7"
+#> [3] "3a5ac2303d2ee6cf9b383b20d2c85e0f" "a4643f65cbe9a61e7b8de845d67a59d4"
+#> [5] "e5ee67e6a65c03d03b135187d87212b0"
 ```
 
 At this point the tasks will proceed through the queue as usual.
@@ -363,11 +363,11 @@ The easiest way to configure this is to save a worker configuration:
 
 ```r
 id <- paste0("rrq:", ids::random_id(bytes = 4))
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 obj$worker_config_save("short", queue = "short")
 obj$worker_config_save("all", queue = c("short", "long"))
 obj$worker_config_list()
-#> [1] "all"       "localhost" "short"
+#> [1] "short"     "all"       "localhost"
 ```
 
 Above, we create two configurations: "short" which just listens on the queue `short`, and `all` which listens both on the short and long task queues (note that both these workers will also listen on the default queue).
@@ -375,11 +375,11 @@ Above, we create two configurations: "short" which just listens on the queue `sh
 
 ```r
 rrq::worker_spawn(obj, worker_config = "short")
-#> Spawning 1 worker with prefix benighted_iridescentshark
-#> [1] "benighted_iridescentshark_1"
+#> Spawning 1 worker with prefix moonstone_shelduck
+#> [1] "moonstone_shelduck_1"
 rrq::worker_spawn(obj, worker_config = "all")
-#> Spawning 1 worker with prefix theosophic_prayingmantis
-#> [1] "theosophic_prayingmantis_1"
+#> Spawning 1 worker with prefix downy_xoni
+#> [1] "downy_xoni_1"
 ```
 
 We can then submit a long task to the worker:
@@ -396,8 +396,8 @@ After the workers have had the ability to pick up work, our "short" worker is st
 
 ```r
 obj$worker_status()
-#> benighted_iridescentshark_1  theosophic_prayingmantis_1
-#>                      "IDLE"                      "BUSY"
+#> moonstone_shelduck_1         downy_xoni_1
+#>               "IDLE"               "BUSY"
 ```
 
 So we can submit tasks to this short queue and have them processed
@@ -406,7 +406,7 @@ So we can submit tasks to this short queue and have them processed
 ```r
 id <- obj$enqueue(runif(1), queue = "short")
 obj$task_wait(id, timeout = 10)
-#> [1] 0.6054476
+#> [1] 0.5236756
 ```
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
@@ -452,10 +452,10 @@ then we create the queue object as normal (and spawn a worker so that we can use
 
 
 ```r
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 rrq::worker_spawn(obj, 1)
-#> Spawning 1 worker with prefix cleanshaven_octopus
-#> [1] "cleanshaven_octopus_1"
+#> Spawning 1 worker with prefix lexicographical_sambar
+#> [1] "lexicographical_sambar_1"
 ```
 
 It's not that hard to get to 1MB of data, we can do that by simulating a big pile of random numbers:
@@ -472,7 +472,7 @@ Once the task has finished, data will be stored on disk below the path given abo
 
 ```r
 dir(path)
-#> [1] "aca21e339d0f2e81ec44d5da4bbe3b7328c1cb8b18d2f657c0e02877efa58705"
+#> [1] "e5461323a584057e36fd2acc498ef923c7715eb52ddf5814027e74f7d31251fd"
 ```
 
 This keeps the larger objects out of the database.

--- a/vignettes_src/messages.Rmd
+++ b/vignettes_src/messages.Rmd
@@ -9,6 +9,7 @@ vignette: >
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
+  error = FALSE,
   collapse = TRUE,
   comment = "#>"
 )
@@ -39,7 +40,7 @@ vignette shows what the possible messages do.
 
 In order to do this, we're going to need a queue and a worker:
 ```{r}
-obj <- rrq::rrq_controller("rrq:messages")
+obj <- rrq::rrq_controller$new("rrq:messages")
 logdir <- tempfile()
 worker_id <- rrq::worker_spawn(obj, logdir = logdir)
 ```

--- a/vignettes_src/rrq.Rmd
+++ b/vignettes_src/rrq.Rmd
@@ -9,6 +9,7 @@ vignette: >
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
+  error = FALSE,
   collapse = TRUE,
   comment = "#>"
 )
@@ -32,7 +33,7 @@ Without any great explanation, here is the basic approach to using rrq to run a 
 
 ```{r}
 id <- paste0("rrq:", ids::random_id(bytes = 4))
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 ```
 
 This controller uses an "identifier" (here, `id` is `r id`) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
@@ -233,7 +234,7 @@ Here we have some function `create` that we want to run first, doing some setup,
 Create an `rrq_controller` object and tell workers to read the `deps.R` file which contains these function definitions
 
 ```{r}
-obj <- rrq::rrq_controller(paste0("rrq:", ids::random_id(bytes = 4)))
+obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
 obj$envir(rrq::rrq_envir(sources = "deps.R"))
 source("deps.R")
 ```
@@ -296,7 +297,7 @@ The easiest way to configure this is to save a worker configuration:
 
 ```{r}
 id <- paste0("rrq:", ids::random_id(bytes = 4))
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 obj$worker_config_save("short", queue = "short")
 obj$worker_config_save("all", queue = c("short", "long"))
 obj$worker_config_list()
@@ -373,7 +374,7 @@ rrq::rrq_configure(id, store_max_size = 1000, offload_path = path)
 then we create the queue object as normal (and spawn a worker so that we can use it)
 
 ```{r}
-obj <- rrq::rrq_controller(id)
+obj <- rrq::rrq_controller$new(id)
 rrq::worker_spawn(obj, 1)
 ```
 


### PR DESCRIPTION
This PR removes the helper `rrq_controller()` function and instead uses the R6 constructor directly.

I've not added any compatibility helpers (unlike in https://github.com/mrc-ide/odin/pull/227) as the current user list is small enough that we can patch them up directly.

Once merged, update:
* https://github.com/mrc-ide/hintr/pull/291
* https://github.com/mrc-ide/didehpc/pull/98

The spimalot PR will work with either version