### PR TITLE
fix #56: redis_command error WRONGTYPE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1461,7 +1461,7 @@ worker_delete_exited <- function(con, keys, worker_ids = NULL) {
   }
 
   if (length(worker_ids) > 0L) {
-    con$HDEL(keys$worker_name,   worker_ids)
+    con$SREM(keys$worker_name,   worker_ids)
     con$HDEL(keys$worker_status, worker_ids)
     con$HDEL(keys$worker_task,   worker_ids)
     con$HDEL(keys$worker_info,   worker_ids)


### PR DESCRIPTION
When one or more workers were running and at the same time one or more workers were lost
doing:
```
rrq_controller$worker_detect_exited()
rrq_controller$worker_delete_exited()
```

resulted an error:
```
Error in redis_command(ptr, cmd) :
  WRONGTYPE Operation against a key holding the wrong kind of value
```