### PR TITLE
Store times alongside tasks

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,9 +12,11 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -27,11 +29,6 @@ jobs:
         with:
           redis-version: "4.x"
 
-      - name: "[macOS] system dependencies"
-        if: runner.os == 'macOS'
-        run: |
-          brew install hiredis
-
       - name: Query dependencies
         run: |
           install.packages('remotes')
@@ -39,12 +36,13 @@ jobs:
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Install system dependencies
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          sudo apt install libcurl4-openssl-dev
 
       - name: Install dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.5.4
+Version: 0.5.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     storr,
     testthat,
     withr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Language: en-GB

--- a/R/keys.R
+++ b/R/keys.R
@@ -36,15 +36,15 @@ rrq_keys_common <- function(queue_id) {
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
 
-       ## Times are 1: submit, 2: start, 3: complete (finish/error/cancel/etc)
-       task_time1     = sprintf("%s:task:time1",      queue_id),
-       task_time2     = sprintf("%s:task:time2",      queue_id),
-       task_time3     = sprintf("%s:task:time3",      queue_id),
-
        ## This is the key where we store the extra complete key we
        ## might push to at.
        task_complete  = sprintf("%s:task:complete",  queue_id),
        task_cancel    = sprintf("%s:task:cancel",    queue_id),
+
+       ## Used for tracking times through the task lifecycle
+       task_time_submit   = sprintf("%s:task:time_submit",   queue_id),
+       task_time_start    = sprintf("%s:task:time_start",    queue_id),
+       task_time_complete = sprintf("%s:task:time_complete", queue_id),
 
        deferred_set   = sprintf("%s:deferred", queue_id))
 }

--- a/R/keys.R
+++ b/R/keys.R
@@ -35,6 +35,12 @@ rrq_keys_common <- function(queue_id) {
        task_timeout   = sprintf("%s:task:timeout",   queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
+
+       ## Times are 1: submit, 2: start, 3: complete (finish/error/cancel/etc)
+       task_time1     = sprintf("%s:task:time1",      queue_id),
+       task_time2     = sprintf("%s:task:time2",      queue_id),
+       task_time3     = sprintf("%s:task:time3",      queue_id),
+
        ## This is the key where we store the extra complete key we
        ## might push to at.
        task_complete  = sprintf("%s:task:complete",  queue_id),

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -778,9 +778,9 @@ rrq_controller <- R6::R6Class(
         as.numeric(list_to_character(time))
       }
       ret <- cbind(
-        submit = read_time_with_default(self$keys$task_time1),
-        start = read_time_with_default(self$keys$task_time2),
-        complete = read_time_with_default(self$keys$task_time3))
+        submit = read_time_with_default(self$keys$task_time_submit),
+        start = read_time_with_default(self$keys$task_time_start),
+        complete = read_time_with_default(self$keys$task_time_complete))
       rownames(ret) <- task_ids
       ret
     },
@@ -1351,7 +1351,7 @@ task_submit_n <- function(con, keys, task_ids, dat, key_complete, queue,
       redis$HMSET(keys$task_status, task_ids, rep_len(TASK_PENDING, n)),
       redis$HMSET(keys$task_queue, task_ids, rep_len(queue, n)),
       redis$HMSET(keys$task_local, task_ids, rep_len(local, n)),
-      redis$HMSET(keys$task_time1, task_ids, rep_len(time, n))),
+      redis$HMSET(keys$task_time_submit, task_ids, rep_len(time, n))),
     timeout)
   if (length(depends_on) > 0) {
     cmds <- c(

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -362,7 +362,7 @@ rrq_controller <- R6::R6Class(
                    queue = queue, separate_process = separate_process,
                    task_timeout = task_timeout,
                    depends_on = depends_on, collect_timeout = collect_timeout,
-                   time_poll = time_poll, progress = NULL)
+                   time_poll = time_poll, progress = progress)
     },
 
     ##' @description The "standard evaluation" version of `$lapply()`.

--- a/R/utils.R
+++ b/R/utils.R
@@ -168,17 +168,18 @@ wait_success <- function(explanation, timeout, keep_going,
   t_end <- Sys.time() + timeout
   out <- NULL
   while (is.null(out)) {
-    out <- tryCatch(keep_going(),
-                     error = function(e) {
-                       if (Sys.time() > t_end) {
-                         e$message <- sprintf("Timeout: %s\n%s", explanation,
-                                              e$message)
-                         stop(e)
-                       } else {
-                         message(e$message)
-                       }
-                     })
-    Sys.sleep(poll)
+    out <- tryCatch(
+      keep_going(),
+      error = function(e) {
+        if (Sys.time() > t_end) {
+          e$message <- sprintf("Timeout: %s\n%s", explanation,
+                               e$message)
+          stop(e)
+        } else {
+          message(e$message)
+          Sys.sleep(poll)
+        }
+      })
   }
   out
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -217,3 +217,8 @@ is_serialized_object <- function(x) {
 squote <- function(x) {
   sprintf("'%s'", x)
 }
+
+
+timestamp <- function(time = Sys.time()) {
+  as.numeric(as.POSIXlt(time, tz = "UTC"))
+}

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -92,15 +92,15 @@ worker_run_task_start <- function(worker, private, task_id) {
   name <- worker$name
   dat <- private$con$pipeline(
     worker_log(redis, keys, "TASK_START", task_id, private$verbose),
-    redis$HSET(keys$worker_status, name,      WORKER_BUSY),
-    redis$HSET(keys$worker_task,   name,      task_id),
-    redis$HSET(keys$task_worker,   task_id,   name),
-    redis$HSET(keys$task_status,   task_id,   TASK_RUNNING),
-    redis$HSET(keys$task_time2,    task_id,   timestamp()),
-    redis$HGET(keys$task_complete, task_id),
-    redis$HGET(keys$task_local,    task_id),
-    redis$HGET(keys$task_expr,     task_id),
-    redis$HGET(keys$task_cancel,   task_id))
+    redis$HSET(keys$worker_status,   name,    WORKER_BUSY),
+    redis$HSET(keys$worker_task,     name,    task_id),
+    redis$HSET(keys$task_worker,     task_id, name),
+    redis$HSET(keys$task_status,     task_id, TASK_RUNNING),
+    redis$HSET(keys$task_time_start, task_id, timestamp()),
+    redis$HGET(keys$task_complete,   task_id),
+    redis$HGET(keys$task_local,      task_id),
+    redis$HGET(keys$task_expr,       task_id),
+    redis$HGET(keys$task_cancel,     task_id))
 
   ## This holds the bits of worker state we might need to refer to
   ## later for a running task:
@@ -127,11 +127,11 @@ worker_run_task_cleanup <- function(worker, private, status, value) {
   task_result <- private$store$set(value, task_id)
 
   private$con$pipeline(
-    redis$HSET(keys$task_result,    task_id,  task_result),
-    redis$HSET(keys$task_status,    task_id,  status),
-    redis$HSET(keys$task_time3,     task_id,  timestamp()),
-    redis$HSET(keys$worker_status,  name,     WORKER_IDLE),
-    redis$HDEL(keys$worker_task,    name),
+    redis$HSET(keys$task_result,        task_id, task_result),
+    redis$HSET(keys$task_status,        task_id, status),
+    redis$HSET(keys$task_time_complete, task_id, timestamp()),
+    redis$HSET(keys$worker_status,      name,    WORKER_IDLE),
+    redis$HDEL(keys$worker_task,        name),
     redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
     if (!is.null(key_complete)) {
       redis$RPUSH(key_complete, task_id)

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -96,6 +96,7 @@ worker_run_task_start <- function(worker, private, task_id) {
     redis$HSET(keys$worker_task,   name,      task_id),
     redis$HSET(keys$task_worker,   task_id,   name),
     redis$HSET(keys$task_status,   task_id,   TASK_RUNNING),
+    redis$HSET(keys$task_time2,    task_id,   timestamp()),
     redis$HGET(keys$task_complete, task_id),
     redis$HGET(keys$task_local,    task_id),
     redis$HGET(keys$task_expr,     task_id),
@@ -103,12 +104,12 @@ worker_run_task_start <- function(worker, private, task_id) {
 
   ## This holds the bits of worker state we might need to refer to
   ## later for a running task:
-  private$active_task <- list(task_id = task_id, key_complete = dat[[6]])
+  private$active_task <- list(task_id = task_id, key_complete = dat[[7]])
 
   ## And this holds the data used in worker_run_task_to actually run
   ## the task
-  ret <- bin_to_object(dat[[8]])
-  ret$separate_process <- dat[[7]] == "FALSE" # NOTE: not a coersion
+  ret <- bin_to_object(dat[[9]])
+  ret$separate_process <- dat[[8]] == "FALSE" # NOTE: not a coersion
   ret$id <- task_id
   ret
 }
@@ -128,6 +129,7 @@ worker_run_task_cleanup <- function(worker, private, status, value) {
   private$con$pipeline(
     redis$HSET(keys$task_result,    task_id,  task_result),
     redis$HSET(keys$task_status,    task_id,  status),
+    redis$HSET(keys$task_time3,     task_id,  timestamp()),
     redis$HSET(keys$worker_status,  name,     WORKER_IDLE),
     redis$HDEL(keys$worker_task,    name),
     redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),

--- a/extra/.gitignore
+++ b/extra/.gitignore
@@ -1,0 +1,3 @@
+*.html
+*.md
+benchmark_files

--- a/extra/Makefile
+++ b/extra/Makefile
@@ -2,15 +2,11 @@ RSCRIPT = Rscript --no-init-file
 
 all: benchmark.html
 
-%.md: %.Rmd
-	${RSCRIPT} -e "knitr::knit('$<')"
-	sed -i.bak 's/[[:space:]]*$$//' $@
-	rm -f $@.bak
-%.html: %.md
-	${RSCRIPT} -e 'markdown::markdownToHTML("$<", "$@")'
+benchmark.html: benchmark.Rmd
+	Rscript -e "rmarkdown::render('$<')"
 
 clean:
-	rm -f benchmark.Rmd benchmark.md benchmark.html
+	rm -f benchmark.md benchmark.html
 	rm -rf figure
 
 .SECONDARY: benchmark.md

--- a/extra/benchmark.Rmd
+++ b/extra/benchmark.Rmd
@@ -7,50 +7,29 @@ when you have something that takes a significant amount of time,
 but knowing what the overhead is may help determine what
 "significant" means here.
 
-The `parallel` package will not parallelise anything that uses just
-one core, or just one job so we have to start from two cores and
-two jobs for a fair comparison (otherwise `parallel` stays
-in-process which is way faster).
-
 ``` {r echo = FALSE, results = "hide"}
 knitr::opts_chunk$set(error = FALSE)
 ```
 
-A simple benchmark attempt:
-``` {r }
-root <- tempfile()
-context <- context::context_load(context::context_save(root))
-obj <- rrq::rrq_controller$new(context, redux::hiredis())
+A controller to throw jobs at:
 
-wid <- rrq::worker_spawn(obj, 2L, logdir = tempdir())
+```{r}
+id <- paste0("rrq:", ids::random_id(bytes = 4))
+obj <- rrq::rrq_controller$new(id)
+rrq::worker_spawn(obj, 1)
 ```
 
-Look in particular at `elapsed`
-``` {r }
+Running a thousand trivial jobs (look in particular at `elapsed` as we're interested in wall time)
+
+```{r}
 system.time(obj$lapply(1:1000, identity, progress = FALSE))
 ```
 
-In contrast with the built in socket cluster (though this also pays
-for the `fork()` operation):
-``` {r }
-system.time(parallel::mclapply(1:1000, identity,
-                               mc.preschedule = FALSE, mc.cores = 2L))
-```
+Then over a matrix of numbers of tasks and workers:
 
-Of course, not prescheduling will totally destroy either approach,
-as it has only a single roundtrip.
-``` {r }
-system.time(parallel::mclapply(1:1000, identity,
-                               mc.preschedule = TRUE, mc.cores = 2L))
-```
-
-Let's check this over a matrix of n and workers.  This has to be
-done somewhat annoyingly:
-``` {r }
-f_rrq <- function(n, nrep, nworkers) {
-  if (interactive()) {
-    message(sprintf("%d / %d / %d", n, nrep, nworkers))
-  }
+```{r run_benchmarks}
+bench_rrq <- function(n, nworkers, nrep, obj) {
+  message(sprintf("%d / %d / %d", n, nrep, nworkers))
   diff <- nworkers - obj$worker_len()
   if (diff > 0L) {
     rrq::worker_spawn(obj, diff, logdir = tempdir())
@@ -62,95 +41,47 @@ f_rrq <- function(n, nrep, nworkers) {
     nrep,
     system.time(obj$lapply(i, identity, progress = FALSE))[["elapsed"]])
 }
-f_mc <- function(n, nrep, nworkers) {
-  if (interactive()) {
-    message(sprintf("%d / %d / %d", n, nrep, nworkers))
-  }
-  i <- seq_len(n)
-  replicate(
-    nrep,
-    system.time(parallel::mclapply(i, identity, mc.cores = nworkers,
-                                   mc.preschedule = FALSE))[["elapsed"]])
-}
 
-n <- round(exp(seq(log(2), log(1024), length.out = 7)))
-nw <- 2:8
+n <- 2^c(1, 3, 5, 7, 9, 11)
+nw <- 1:8
 nrep <- 10
-dat <- expand.grid(n = n, nrep = nrep, nworkers = nw)
+dat <- expand.grid(n = n, nworkers = nw)
+times <- Map(bench_rrq, dat$n, dat$nworkers, nrep, list(obj))
+time <- matrix(vapply(times, median, numeric(1)), length(n)) * 1000
 ```
 
-``` {r compute_mc}
-y_mc <-
-  vapply(seq_len(nrow(dat)), function(i)
-    do.call(f_mc, dat[i, ], quote = TRUE),
-    numeric(nrep))
-```
+Total time taken
 
-``` {r compute_rrq}
-y_rrq <- vapply(seq_len(nrow(dat)), function(i)
-  do.call(f_rrq, dat[i, ], quote = TRUE),
-  numeric(nrep))
-```
-
-Convert these into nice matrices, taking the median execution time:
-``` {r }
-m_mc <- matrix(apply(y_mc, 2, median), length(n))
-m_rrq <- matrix(apply(y_rrq, 2, median), length(n))
-```
-
-Zeros cause trouble later, so set them to the minimum reported time
-``` {r }
-m_mc[m_mc == 0] <- 0.0001
-m_rrq[m_rrq == 0] <- 0.0001
-
+```{r}
 cols <- RColorBrewer::brewer.pal(length(nw), "Blues")
+matplot(n, time, type = "l", log = "xy", lty = 1, col = cols,
+        xlab = "Number of tasks", ylab = "Total time (ms)")
+legend("topleft", legend = nw, col = cols, lty = 1, bty = "n")
+text(n[length(n)], time[nrow(time), ], adj = -0.5, cex = 0.5)
 ```
 
-For multicore, the total time taken is not really affected by the
-number of processors.  There's a very slight cost at low n and a
-very slight gain at high n.
-``` {r mc_total}
-ylim <- range(m_mc, m_rrq)
-matplot(n, m_mc, type = "l", log = "xy", lty = 1, col = cols, ylim = ylim,
-        ylab = "parallel, total time")
+Time per call (the increase on the rhs is probably due to the cost of submitting the tasks, which is done in serial)
+
+```{r}
+time_call <- time / n
+matplot(n, time_call, type = "l", log = "xy", lty = 1, col = cols,
+        xlab = "Number of tasks", ylab = "Per-call time (ms / call)")
+legend("topright", legend = nw, col = cols, lty = 1, bty = "n")
+text(n[length(n)], time_call[nrow(time_call), ], adj = -0.5, cex = 0.5)
 ```
 
-With `rrq`, the number of processors does decrease the total
-computation time, though it's very modest.
-``` {r rrq_total}
-matplot(n, m_rrq, type = "l", log = "xy", lty = 1, col = cols, ylim = ylim,
-        ylab = "rrq, total time")
-abline(h = max(m_mc), lty = 3, col = "blue")
-abline(h = min(m_mc), lty = 3, col = "red")
+Time per call per worker
+
+```{r}
+time_call_worker <- time / n / rep(nw, each = nrow(time))
+matplot(n, time_call_worker, type = "l", log = "xy", lty = 1, col = cols,
+        xlab = "Number of tasks",
+        ylab = "Per-call-per-worker time (ms / call / worker)")
+legend("topright", legend = nw, col = cols, lty = 1, bty = "n")
+text(n[length(n)], time_call_worker[nrow(time_call_worker), ],
+     adj = -0.5, cex = 0.5)
 ```
 
-As the number of elements being parallised over increases, the
-per-element cost shrinks to around 0.001s
-``` {r mc_percall}
-ylim <- range(m_mc / n, m_rrq / n)
-matplot(n, m_mc / n, type = "l", log = "xy", lty = 1, col = cols, ylim = ylim,
-        ylab = "parallel, per-call time")
-```
-
-The per-element floor for `rrq` on one processor is a little
-faster, dropping to ~1/2 this for more than one processor (the
-fastest parallel time is shown in red, slowest in blue)
-``` {r rrq_percall}
-matplot(n, m_rrq / n, type = "l", log = "xy", lty = 1, col = cols, ylim = ylim,
-        ylab = "rrq, per-call time")
-abline(h = max(m_mc / n), lty = 3, col = "blue")
-abline(h = min(m_mc / n), lty = 3, col = "red")
-```
-
-multicore is faster than `rrq` for small n (probably because there
-is a nontrivial overhead in doing some function checking and
-expression analysis in rrq) but over larger n rrq is faster (above
-about n = 20 here).  With more than one processor, `rrq` is faster
-by a greater margin, and across a wider range of n.
-``` {r relative}
-matplot(n, m_rrq / m_mc, type = "l", log = "x", lty = 1, col = cols,
-        ylab = "rrq time relative to parallel time")
-abline(h = 1, lty = 3, col = "red")
-
+```{r}
 obj$destroy()
 ```

--- a/extra/benchmark.Rmd
+++ b/extra/benchmark.Rmd
@@ -1,3 +1,10 @@
+---
+title: "rrq benchmarks"
+author: "Rich FitzJohn"
+date: "`r format(Sys.Date())`"
+output: github_document
+---
+
 # rrq benchmarks
 
 These benchmarks aim to measure the per-call overhead of the
@@ -29,10 +36,12 @@ Then over a matrix of numbers of tasks and workers:
 
 ```{r run_benchmarks}
 bench_rrq <- function(n, nworkers, nrep, obj) {
-  message(sprintf("%d / %d / %d", n, nrep, nworkers))
+  if (interactive()) {
+    message(sprintf("%d / %d / %d", n, nrep, nworkers))
+  }
   diff <- nworkers - obj$worker_len()
   if (diff > 0L) {
-    rrq::worker_spawn(obj, diff, logdir = tempdir())
+    suppressMessages(rrq::worker_spawn(obj, diff))
   } else if (diff < 0L) {
     obj$worker_stop(obj$worker_list()[seq_len(-diff)])
   }
@@ -43,7 +52,7 @@ bench_rrq <- function(n, nworkers, nrep, obj) {
 }
 
 n <- 2^c(1, 3, 5, 7, 9, 11)
-nw <- 1:8
+nw <- 1:4
 nrep <- 10
 dat <- expand.grid(n = n, nworkers = nw)
 times <- Map(bench_rrq, dat$n, dat$nworkers, nrep, list(obj))

--- a/extra/requirements.txt
+++ b/extra/requirements.txt
@@ -1,3 +1,0 @@
-pyyaml
-redis
-uuid

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -162,6 +162,7 @@ ans <- obj$lapply_(1:10, quote(log), base = quote(b))
 \item \href{#method-task_delete}{\code{rrq_controller$task_delete()}}
 \item \href{#method-task_cancel}{\code{rrq_controller$task_cancel()}}
 \item \href{#method-task_data}{\code{rrq_controller$task_data()}}
+\item \href{#method-task_times}{\code{rrq_controller$task_times()}}
 \item \href{#method-queue_length}{\code{rrq_controller$queue_length()}}
 \item \href{#method-queue_list}{\code{rrq_controller$queue_list()}}
 \item \href{#method-queue_remove}{\code{rrq_controller$queue_remove()}}
@@ -1057,6 +1058,30 @@ Fetch internal data about a task from Redis
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{task_id}}{The id of the task}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-task_times"></a>}}
+\if{latex}{\out{\hypertarget{method-task_times}{}}}
+\subsection{Method \code{task_times()}}{
+Fetch times for tasks at points in their life cycle.
+For each task returns the time of submission, starting
+and completion (not necessarily successfully; this includes
+errors and interruptions).  If a task has not reacched a point
+yet (e.g., submitted but not run, or running but not finished)
+the time will be \code{NA}).  Times are returned in unix timestamp
+format in UTC; you can use \link[redux:redis_time]{redux::redis_time_to_r} to convert
+them to a POSIXt object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_times(task_ids)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{task_ids}}{Task ids to fetch times for.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -944,3 +944,21 @@ test_that("offload storage in result", {
   expect_equal(store$list(), character(0))
   expect_equal(dir(path), character(0))
 })
+
+
+test_that("collect times", {
+  obj <- test_rrq("myfuns.R")
+  ## What is the pause here for? Something is taking much longer than
+  ## we expect
+  w <- test_worker_blocking(obj)
+
+  t <- obj$enqueue(slowdouble(0.1))
+  expect_type(t, "character")
+  w$step(TRUE)
+  expect_equal(obj$task_wait(t, 2), 0.2)
+  expect_equal(obj$task_result(t), 0.2)
+  times <- obj$task_times(t)
+  expect_true(is.matrix(times)) # testthat 3e makes this quite hard
+  expect_equal(dimnames(times), list(t, c("submit", "start", "complete")))
+  expect_type(times, "double")
+})


### PR DESCRIPTION
This does incur a small extra overhead but it's not that bad, and seems to disappear when you add a few workers.

This PR:

* tides up the incredibly out of date benchmarking
* adds support for saving times out

There are 3 reliable times we can get - the time of submission (perhaps that is uninteresting?), the time of task start (we know we want that!) and the time of task finishing.  These are saved into 3 hashes at the points where we save job status back, which are all quite nicely defined.

Very open to new names (start/submit/complete), drawing a blank on something better