### PR TITLE
Fix task wait

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.5.5
+Version: 0.5.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/bulk.R
+++ b/R/bulk.R
@@ -38,7 +38,7 @@ rrq_bulk_submit <- function(con, keys, store, x, fun, dots, do_call,
   }
 
   key_complete <- rrq_key_task_complete(keys$queue_id)
-  task_submit_n(con, keys, task_ids, dat, key_complete, queue,
+  task_submit_n(con, keys, store, task_ids, dat, key_complete, queue,
                 separate_process, task_timeout,
                 depends_on = depends_on)
   ret <- list(task_ids = task_ids,

--- a/R/common.R
+++ b/R/common.R
@@ -32,8 +32,11 @@ TASK <- list(
   ## Possible status for all finished but incomplete/failed tasks
   terminal_fail = c(TASK_ERROR, TASK_CANCELLED, TASK_DIED, TASK_TIMEOUT,
                     TASK_IMPOSSIBLE),
-  ## Possible status for all unrun tasks
-  waiting = c(TASK_PENDING, TASK_DEFERRED))
+  ## Possible status for all non-started tasks
+  unstarted = c(TASK_PENDING, TASK_DEFERRED),
+  ## Possible status for all non-finished tasks
+  unfinished = c(TASK_PENDING, TASK_DEFERRED, TASK_RUNNING))
+
 ## Possible status for all finished tasks
 TASK$terminal <- c(TASK$terminal_fail, TASK_COMPLETE)
 

--- a/R/common.R
+++ b/R/common.R
@@ -24,6 +24,19 @@ TASK_DEFERRED <- "DEFERRED"
 ## dependency errored so this tasks condition can never be satisfied
 TASK_IMPOSSIBLE <- "IMPOSSIBLE"
 
+
+TASK <- list(
+  ## Possible status for all known tasks (i.e. all non-missing statuses)
+  all = c(TASK_PENDING, TASK_RUNNING, TASK_COMPLETE, TASK_ERROR, TASK_CANCELLED,
+          TASK_DIED, TASK_TIMEOUT, TASK_MISSING, TASK_DEFERRED),
+  ## Possible status for all finished but incomplete/failed tasks
+  terminal_fail = c(TASK_ERROR, TASK_CANCELLED, TASK_DIED, TASK_TIMEOUT,
+                    TASK_IMPOSSIBLE),
+  ## Possible status for all unrun tasks
+  waiting = c(TASK_PENDING, TASK_DEFERRED))
+## Possible status for all finished tasks
+TASK$terminal <- c(TASK$terminal_fail, TASK_COMPLETE)
+
 WORKER_IDLE <- "IDLE"
 WORKER_BUSY <- "BUSY"
 WORKER_EXITED <- "EXITED"

--- a/R/common.R
+++ b/R/common.R
@@ -28,7 +28,7 @@ TASK_IMPOSSIBLE <- "IMPOSSIBLE"
 TASK <- list(
   ## Possible status for all known tasks (i.e. all non-missing statuses)
   all = c(TASK_PENDING, TASK_RUNNING, TASK_COMPLETE, TASK_ERROR, TASK_CANCELLED,
-          TASK_DIED, TASK_TIMEOUT, TASK_MISSING, TASK_DEFERRED),
+          TASK_DIED, TASK_TIMEOUT, TASK_IMPOSSIBLE, TASK_DEFERRED),
   ## Possible status for all finished but incomplete/failed tasks
   terminal_fail = c(TASK_ERROR, TASK_CANCELLED, TASK_DIED, TASK_TIMEOUT,
                     TASK_IMPOSSIBLE),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -18,10 +18,10 @@ cancel_dependencies <- function(con, keys, store, ids) {
   dependent_ids <- unique(unlist(lapply(dependent_keys, con$SMEMBERS)))
   n <- length(dependent_ids)
 
-  value <- worker_task_failed(TASK_IMPOSSIBLE)
-  lapply(dependent_ids, function(id) {
-    run_task_cleanup(con, keys, store, id, TASK_IMPOSSIBLE, value)
-  })
+  run_task_cleanup(
+    con, keys, store, dependent_ids,
+    rep(TASK_IMPOSSIBLE, length(dependent_ids)),
+    rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(dependent_ids)))
 
   if (n > 0) {
     cancel_dependencies(con, keys, store, dependent_ids)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -18,10 +18,8 @@ cancel_dependencies <- function(con, keys, store, ids) {
   dependent_ids <- unique(unlist(lapply(dependent_keys, con$SMEMBERS)))
   n <- length(dependent_ids)
 
-  run_task_cleanup(
-    con, keys, store, dependent_ids,
-    rep(TASK_IMPOSSIBLE, length(dependent_ids)),
-    rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(dependent_ids)))
+  run_task_cleanup(con, keys, store, dependent_ids, TASK_IMPOSSIBLE,
+                   worker_task_failed(TASK_IMPOSSIBLE))
 
   if (n > 0) {
     cancel_dependencies(con, keys, store, dependent_ids)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -17,11 +17,6 @@ cancel_dependencies <- function(con, keys, store, ids) {
 }
 
 queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
-  dependent_keys <- rrq_key_task_dependents(keys$queue_id, task_id)
-  dependent_ids <- con$SMEMBERS(dependent_keys)
-  if (length(dependent_ids) == 0) {
-    return()
-  }
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(
     lapply(dependency_keys, redis$SREM, task_id),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,16 +1,6 @@
-worker_queue_dependencies <- function(con, keys, store, task_id, task_status) {
-  dependent_keys <- rrq_key_task_dependents(keys$queue_id, task_id)
-  dependent_ids <- con$SMEMBERS(dependent_keys)
-  if (length(dependent_ids) == 0) {
-    return()
-  }
-
-  if (identical(task_status, TASK_ERROR)) {
-    cancel_dependencies(con, keys, store, task_id)
-  } else {
-    queue_dependencies(con, keys, task_id, dependent_ids)
-  }
-  invisible(TRUE)
+get_dependent_ids <- function(con, queue_id, task_id) {
+  dependent_keys <- rrq_key_task_dependents(queue_id, task_id)
+  con$SMEMBERS(dependent_keys)
 }
 
 cancel_dependencies <- function(con, keys, store, ids) {
@@ -27,6 +17,11 @@ cancel_dependencies <- function(con, keys, store, ids) {
 }
 
 queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
+  dependent_keys <- rrq_key_task_dependents(keys$queue_id, task_id)
+  dependent_ids <- con$SMEMBERS(dependent_keys)
+  if (length(dependent_ids) == 0) {
+    return()
+  }
   dependency_keys <- rrq_key_task_dependencies(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(
     lapply(dependency_keys, redis$SREM, task_id),

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1238,10 +1238,8 @@ task_delete <- function(con, keys, store, task_ids, check = TRUE) {
     status_dependent <- con$HMGET(keys$task_status, dependents)
     cancel <- dependents[status_dependent == TASK_DEFERRED]
     if (length(cancel) > 0) {
-      run_task_cleanup(
-        con, keys, store, cancel,
-        rep(TASK_IMPOSSIBLE, length(cancel)),
-        rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(cancel)))
+      run_task_cleanup(con, keys, store, cancel, TASK_IMPOSSIBLE,
+                       worker_task_failed(TASK_IMPOSSIBLE))
       cancel_dependencies(con, keys, store, cancel)
     }
   }
@@ -1371,10 +1369,8 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
 
   ## If any dependencies will never be satisfied then cleanup and error
   if (any(response$status %in% TASK$terminal_fail)) {
-    run_task_cleanup(
-      con, keys, store, task_ids,
-      rep(TASK_IMPOSSIBLE, length(task_ids)),
-      rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(task_ids)))
+    run_task_cleanup(con, keys, store, task_ids, TASK_IMPOSSIBLE,
+                     worker_task_failed(TASK_IMPOSSIBLE))
     cancel_dependencies(con, keys, store, task_ids)
     incomplete <- response$status[response$status %in% TASK$terminal_fail]
     names(incomplete) <- depends_on[response$status %in% TASK$terminal_fail]

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1238,10 +1238,10 @@ task_delete <- function(con, keys, store, task_ids, check = TRUE) {
     status_dependent <- con$HMGET(keys$task_status, dependents)
     cancel <- dependents[status_dependent == TASK_DEFERRED]
     if (length(cancel) > 0) {
-      value <- worker_task_failed(TASK_IMPOSSIBLE)
-      lapply(cancel, function(id) {
-        run_task_cleanup(con, keys, store, id, TASK_IMPOSSIBLE, value)
-      })
+      run_task_cleanup(
+        con, keys, store, cancel,
+        rep(TASK_IMPOSSIBLE, length(cancel)),
+        rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(cancel)))
       cancel_dependencies(con, keys, store, cancel)
     }
   }
@@ -1371,10 +1371,10 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
 
   ## If any dependencies will never be satisfied then cleanup and error
   if (any(response$status %in% TASK$terminal_fail)) {
-    value <- worker_task_failed(TASK_IMPOSSIBLE)
-    lapply(task_ids, function(id) {
-      run_task_cleanup(con, keys, store, id, TASK_IMPOSSIBLE, value)
-    })
+    run_task_cleanup(
+      con, keys, store, task_ids,
+      rep(TASK_IMPOSSIBLE, length(task_ids)),
+      rep(list(worker_task_failed(TASK_IMPOSSIBLE)), length(task_ids)))
     cancel_dependencies(con, keys, store, task_ids)
     incomplete <- response$status[response$status %in% TASK$terminal_fail]
     names(incomplete) <- depends_on[response$status %in% TASK$terminal_fail]

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -301,7 +301,7 @@ rrq_controller <- R6::R6Class(
       verify_dependencies_exist(self, depends_on)
       dat <- expression_prepare(expr, envir, private$store, task_id,
                                 export = export)
-      task_submit(self$con, self$keys, task_id, dat, queue,
+      task_submit(self$con, self$keys, private$store, task_id, dat, queue,
                   separate_process, timeout, at_front, depends_on)
     },
 
@@ -1156,9 +1156,8 @@ task_progress <- function(con, keys, task_id) {
 
 
 task_overview <- function(con, keys, task_ids) {
-  lvls <- c(TASK_PENDING, TASK_RUNNING, TASK_COMPLETE, TASK_ERROR)
   status <- task_status(con, keys, task_ids)
-  lvls <- c(lvls, setdiff(unique(status), lvls))
+  lvls <- c(TASK$all, setdiff(unique(status), TASK$all))
   as.list(table(factor(status, lvls)))
 }
 
@@ -1185,11 +1184,11 @@ task_preceeding <- function(con, keys, task_id, queue) {
   queue_contents[seq_len(task_position - 1)]
 }
 
-task_submit <- function(con, keys, task_id, dat, queue,
+task_submit <- function(con, keys, store, task_id, dat, queue,
                         separate_process, timeout, at_front = FALSE,
                         depends_on = NULL) {
-  task_submit_n(con, keys, task_id, list(object_to_bin(dat)), NULL, queue,
-                separate_process, timeout, at_front, depends_on)
+  task_submit_n(con, keys, store, task_id, list(object_to_bin(dat)), NULL,
+                queue, separate_process, timeout, at_front, depends_on)
 }
 
 task_delete <- function(con, keys, store, task_ids, check = TRUE) {
@@ -1233,18 +1232,17 @@ task_delete <- function(con, keys, store, task_ids, check = TRUE) {
   ## B. Their dependencies have not already been deleted or set to ERRORED, etc.
   ## i.e. their dependencies are also DEFERRED
   status <- res[seq_along(task_ids)]
-  ids_to_cancel <- task_ids[unlist(status) %in% c(TASK_PENDING, TASK_DEFERRED)]
+  ids_to_cancel <- task_ids[unlist(status) %in% TASK$waiting]
   dependents <- unique(unlist(res[ids_to_cancel]))
   if (length(dependents) > 0) {
     status_dependent <- con$HMGET(keys$task_status, dependents)
     cancel <- dependents[status_dependent == TASK_DEFERRED]
     if (length(cancel) > 0) {
-      con$pipeline(
-        redis$HMSET(keys$task_status, cancel,
-                    rep_len(TASK_IMPOSSIBLE, length(cancel))),
-        redis$SREM(keys$deferred_set, cancel)
-      )
-      cancel_dependencies(con, keys, cancel)
+      value <- worker_task_failed(TASK_IMPOSSIBLE)
+      lapply(cancel, function(id) {
+        run_task_cleanup(con, keys, store, id, TASK_IMPOSSIBLE, value)
+      })
+      cancel_dependencies(con, keys, store, cancel)
     }
   }
 
@@ -1277,11 +1275,11 @@ task_cancel <- function(con, keys, store, scripts, task_id, wait = FALSE,
 
   task_status <- dat$status %||% TASK_MISSING
 
-  if (!(task_status %in% c(TASK_PENDING, TASK_DEFERRED, TASK_RUNNING))) {
+  if (!(task_status %in% c(TASK$waiting, TASK_RUNNING))) {
     stop(sprintf("Task %s is not cancelable (%s)", task_id, task_status))
   }
 
-  cancel_dependencies(con, keys, task_id)
+  cancel_dependencies(con, keys, store, task_id)
 
   if (task_status == TASK_RUNNING) {
     if (dat$local != "FALSE") {
@@ -1314,7 +1312,7 @@ task_data <- function(con, keys, store, task_id) {
 }
 
 
-task_submit_n <- function(con, keys, task_ids, dat, key_complete, queue,
+task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
                           separate_process, timeout, at_front = FALSE,
                           depends_on = NULL) {
   n <- length(dat)
@@ -1372,17 +1370,14 @@ task_submit_n <- function(con, keys, task_ids, dat, key_complete, queue,
   response <- con$pipeline(.commands = cmds)
 
   ## If any dependencies will never be satisfied then cleanup and error
-  incomplete_status <- c(TASK_ERROR, TASK_DIED, TASK_CANCELLED,
-                         TASK_IMPOSSIBLE)
-  if (any(response$status %in% incomplete_status)) {
-    n <- length(task_ids)
-    con$pipeline(
-      redis$HMSET(keys$task_status, task_ids, rep_len(TASK_IMPOSSIBLE, n)),
-      redis$SREM(keys$deferred_set, task_ids)
-    )
-    cancel_dependencies(con, keys, task_ids)
-    incomplete <- response$status[response$status %in% incomplete_status]
-    names(incomplete) <- depends_on[response$status %in% incomplete_status]
+  if (any(response$status %in% TASK$terminal_fail)) {
+    value <- worker_task_failed(TASK_IMPOSSIBLE)
+    lapply(task_ids, function(id) {
+      run_task_cleanup(con, keys, store, id, TASK_IMPOSSIBLE, value)
+    })
+    cancel_dependencies(con, keys, store, task_ids)
+    incomplete <- response$status[response$status %in% TASK$terminal_fail]
+    names(incomplete) <- depends_on[response$status %in% TASK$terminal_fail]
     stop(sprintf("Failed to queue as dependent tasks failed:\n%s",
                  paste0(paste0(names(incomplete), ": ", incomplete),
                         collapse = ", ")))

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1232,7 +1232,7 @@ task_delete <- function(con, keys, store, task_ids, check = TRUE) {
   ## B. Their dependencies have not already been deleted or set to ERRORED, etc.
   ## i.e. their dependencies are also DEFERRED
   status <- res[seq_along(task_ids)]
-  ids_to_cancel <- task_ids[unlist(status) %in% TASK$waiting]
+  ids_to_cancel <- task_ids[unlist(status) %in% TASK$unstarted]
   dependents <- unique(unlist(res[ids_to_cancel]))
   if (length(dependents) > 0) {
     status_dependent <- con$HMGET(keys$task_status, dependents)
@@ -1275,7 +1275,7 @@ task_cancel <- function(con, keys, store, scripts, task_id, wait = FALSE,
 
   task_status <- dat$status %||% TASK_MISSING
 
-  if (!(task_status %in% c(TASK$waiting, TASK_RUNNING))) {
+  if (!(task_status %in% TASK$unfinished)) {
     stop(sprintf("Task %s is not cancelable (%s)", task_id, task_status))
   }
 

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -1,0 +1,15 @@
+run_task_cleanup <- function(con, keys, store, task_id, status, value) {
+  log_status <- paste0("TASK_", status)
+  task_result <- store$set(value, task_id)
+  key_complete <- con$HGET(keys$task_complete, task_id)
+  con$pipeline(
+    redis$HSET(keys$task_result,        task_id, task_result),
+    redis$HSET(keys$task_status,        task_id, status),
+    redis$HSET(keys$task_time_complete, task_id, timestamp()),
+    redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
+    if (!is.null(key_complete)) {
+      redis$RPUSH(key_complete, task_id)
+    },
+    redis$SREM(keys$deferred_set, task_id)
+  )
+}

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -1,5 +1,5 @@
-run_task_cleanup <- function(con, keys, store, task_ids, statuses, values) {
-  cleanup_one <- function(task_id, status, value) {
+run_task_cleanup <- function(con, keys, store, task_ids, status, value) {
+  cleanup_one <- function(task_id) {
     task_result <- store$set(value, task_id)
     key_complete <- con$HGET(keys$task_complete, task_id)
     list(
@@ -13,6 +13,6 @@ run_task_cleanup <- function(con, keys, store, task_ids, statuses, values) {
       redis$SREM(keys$deferred_set, task_id)
     )
   }
-  cmds <- Map(cleanup_one, task_ids, statuses, values)
+  cmds <- Map(cleanup_one, task_ids)
   con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
 }

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -1,15 +1,18 @@
-run_task_cleanup <- function(con, keys, store, task_id, status, value) {
-  log_status <- paste0("TASK_", status)
-  task_result <- store$set(value, task_id)
-  key_complete <- con$HGET(keys$task_complete, task_id)
-  con$pipeline(
-    redis$HSET(keys$task_result,        task_id, task_result),
-    redis$HSET(keys$task_status,        task_id, status),
-    redis$HSET(keys$task_time_complete, task_id, timestamp()),
-    redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
-    if (!is.null(key_complete)) {
-      redis$RPUSH(key_complete, task_id)
-    },
-    redis$SREM(keys$deferred_set, task_id)
-  )
+run_task_cleanup <- function(con, keys, store, task_ids, statuses, values) {
+  cleanup_one <- function(task_id, status, value) {
+    task_result <- store$set(value, task_id)
+    key_complete <- con$HGET(keys$task_complete, task_id)
+    list(
+      redis$HSET(keys$task_result,        task_id, task_result),
+      redis$HSET(keys$task_status,        task_id, status),
+      redis$HSET(keys$task_time_complete, task_id, timestamp()),
+      redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
+      if (!is.null(key_complete)) {
+        redis$RPUSH(key_complete, task_id)
+      },
+      redis$SREM(keys$deferred_set, task_id)
+    )
+  }
+  cmds <- Map(cleanup_one, task_ids, statuses, values)
+  con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
 }

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -125,7 +125,7 @@ worker_run_task_cleanup <- function(worker, private, status, value) {
   log_status <- paste0("TASK_", status)
 
   run_task_cleanup(private$con, keys, private$store, task$task_id,
-                   status, value)
+                   status, list(value))
 
   private$con$pipeline(
     redis$HSET(keys$worker_status,      name,    WORKER_IDLE),

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -124,8 +124,8 @@ worker_run_task_cleanup <- function(worker, private, status, value) {
   name <- worker$name
   log_status <- paste0("TASK_", status)
 
-  run_task_cleanup(private$con, keys, private$store, task$task_id,
-                   status, list(value))
+  run_task_cleanup(private$con, keys, private$store, task$task_id, status,
+                   value)
 
   private$con$pipeline(
     redis$HSET(keys$worker_status,      name,    WORKER_IDLE),

--- a/tests/testthat/test-bulk-support.R
+++ b/tests/testthat/test-bulk-support.R
@@ -15,9 +15,9 @@ test_that("match_fun_envir can deal with namespaced functions", {
 
 
 test_that("match_fun_envir can deal with hidden functions", {
-  expected <- list(name = quote(ids:::as_integer_bignum),
-                   value = ids:::as_integer_bignum)
-  expect_equal(match_fun_envir(quote(ids:::as_integer_bignum)), expected)
+  expected <- list(name = quote(ids:::cases),
+                   value = ids:::cases)
+  expect_equal(match_fun_envir(quote(ids:::cases)), expected)
 })
 
 
@@ -47,8 +47,8 @@ test_that("match_fun", {
   expect_identical(match_fun("add", e), e$add)
   expect_error(match_fun(1, e), "Could not find function")
   expect_identical(match_fun(quote(ids::random_id), e), ids::random_id)
-  expect_identical(match_fun(quote(ids:::as_integer_bignum), e),
-                   ids:::as_integer_bignum)
+  expect_identical(match_fun(quote(ids:::cases), e),
+                   ids:::cases)
 })
 
 

--- a/tests/testthat/test-common.R
+++ b/tests/testthat/test-common.R
@@ -4,6 +4,7 @@ test_that("task all contains all task statuses", {
   ## a real task can have, it is the NULL status given to
   ## non-existent tasks
   all_task_keys <- setdiff(all_task_keys, "TASK_MISSING")
-  task_all <- vcapply(all_task_keys, get)
+  task_all <- vcapply(all_task_keys,
+                      function(key) get(key, envir = asNamespace("rrq")))
   expect_setequal(task_all, TASK$all)
 })

--- a/tests/testthat/test-common.R
+++ b/tests/testthat/test-common.R
@@ -1,0 +1,9 @@
+test_that("task all contains all task statuses", {
+  all_task_keys <- ls(pattern = "^TASK_", envir = asNamespace("rrq"))
+  ## Deliberately exclude TASK_MISSING as this is not a status
+  ## a real task can have, it is the NULL status given to
+  ## non-existent tasks
+  all_task_keys <- setdiff(all_task_keys, "TASK_MISSING")
+  task_all <- vcapply(all_task_keys, get)
+  expect_setequal(task_all, TASK$all)
+})

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -994,4 +994,3 @@ test_that("collect times", {
   expect_equal(obj$task_times(t2), times1[t2, , drop = FALSE])
   expect_false(any(is.na(times2[t1, ])))
 })
-

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -131,7 +131,7 @@ test_that("task_overview", {
   expect_equal(
     obj$task_overview(),
     list(PENDING = 0, RUNNING = 0, COMPLETE = 0, ERROR = 0, CANCELLED = 0,
-         DIED = 0, TIMEOUT = 0, MISSING = 0, DEFERRED = 0))
+         DIED = 0, TIMEOUT = 0, IMPOSSIBLE = 0, DEFERRED = 0))
 
   t1 <- obj$enqueue(sin(1))
   t2 <- obj$enqueue(sin(1))
@@ -140,7 +140,7 @@ test_that("task_overview", {
   expect_equal(
     obj$task_overview(),
     list(PENDING = 3, RUNNING = 0, COMPLETE = 0, ERROR = 0, CANCELLED = 0,
-         DIED = 0, TIMEOUT = 0, MISSING = 0, DEFERRED = 0))
+         DIED = 0, TIMEOUT = 0, IMPOSSIBLE = 0, DEFERRED = 0))
 })
 
 

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -175,7 +175,7 @@ test_that("Cope with dying subprocess task", {
   t <- obj$enqueue(pid_and_sleep(path, 600), separate_process = TRUE)
 
   wait_status(t, obj)
-  wait_timeout("File did not appear", 5, function() !file.exists(path))
+  wait_timeout("File did not appear", 10, function() !file.exists(path))
 
   pid_sub <- as.integer(readLines(path))
   tools::pskill(pid_sub)


### PR DESCRIPTION
This PR will
* Add some useful groupings of tasks, e.g. TASK$waiting and use these in logic which should help minimise the amount of changes we need to add a new status at any point
* Add a helper for running task cleanup
* Call this when tasks set impossible to make sure task result is saved out so that `task_wait` works for IMPOSSIBLE tasks
* Add test to check that `task_wait` works with IMPOSSIBLE