### PR TITLE
Update rrq_version on worker_info to report version number only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.6.1
+
+* Simplify version information returned by `worker_info` (mrc-2295)
+
 # rrq 0.6.0
 
 * Renamed some functions with `rrq_` prefix; you must now use `rrq_worker_spawn()` (not `worker_spawn`), `rrq_worker_wait`, `rrq_heartbeat` and `rrq_heartbeat_kill` (mrc-2682)

--- a/R/common.R
+++ b/R/common.R
@@ -50,24 +50,5 @@ QUEUE_DEFAULT <- "default"
 ## nolint end
 
 version_info <- function(package = "rrq") {
-  descr <- packageDescription(package)
-  version <- package_version(descr$Version)
-  repository <- descr$Repository
-  sha <- descr$RemoteSha
-  list(package = package,
-       version = version,
-       repository = repository,
-       packaged = descr$Packaged %||% "(unknown packaged)",
-       sha = sha)
-}
-
-version_string <- function(data = version_info()) {
-  if (!is.null(data$repository)) {
-    qual <- sprintf("%s; %s", data$repository, data$packaged)
-  } else if (!is.null(data$sha)) {
-    qual <- data$sha
-  } else {
-    qual <- "LOCAL"
-  }
-  sprintf("%s [%s]", data$version, qual)
+  as.character(packageVersion(package))
 }

--- a/R/worker.R
+++ b/R/worker.R
@@ -306,7 +306,7 @@ worker_info_collect <- function(worker, private) {
   sys <- sessionInfo()
   redis_config <- private$con$config()
   dat <- list(worker = worker$name,
-              rrq_version = version_string(),
+              rrq_version = version_info(),
               platform = sys$platform,
               running = sys$running,
               hostname = hostname(),

--- a/tests/testthat/test-common.R
+++ b/tests/testthat/test-common.R
@@ -8,3 +8,7 @@ test_that("task all contains all task statuses", {
                       function(key) get(key, envir = asNamespace("rrq")))
   expect_setequal(task_all, TASK$all)
 })
+
+test_that("can get version info", {
+  expect_match(version_info(), "\\d+\\.\\d+\\.\\d+")
+})

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -261,3 +261,23 @@ test_that("clean up worker when one still running", {
   expect_equal(obj$worker_list_exited(), character(0))
   expect_equal(obj$worker_delete_exited(), character(0))
 })
+
+
+test_that("can get worker info", {
+  skip_if_not_installed("callr")
+  skip_on_os("windows")
+
+  obj <- test_rrq()
+  res <- obj$worker_config_save("localhost", heartbeat_period = 3)
+  wid <- test_worker_spawn(obj)
+  on.exit(obj$worker_stop(wid, "kill_local"))
+
+  info <- obj$worker_info(wid)
+  expect_length(info, 1)
+  expect_equal(names(info), wid)
+  expect_setequal(names(info[[wid]]),
+                  c("worker", "rrq_version", "platform", "running", "hostname",
+                    "username", "queue", "wd", "pid", "redis_host",
+                    "redis_port", "heartbeat_key"))
+  expect_equal(info[[wid]]$rrq_version, version_info())
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -53,20 +53,6 @@ test_that("assert_scalar_logical", {
 })
 
 
-test_that("version_string", {
-  dat <- version_info("R6")
-  expect_match(version_string(dat),
-               sprintf("%s \\[.*\\]$", dat$version))
-  dat$repository <- NULL
-  dat$sha <- NULL
-  expect_match(version_string(dat),
-               sprintf("%s \\[LOCAL\\]$", dat$version))
-  dat$sha <- "aaa"
-  expect_match(version_string(dat),
-               sprintf("%s \\[aaa\\]$", dat$version))
-})
-
-
 test_that("bin_to_object_safe", {
   d <- runif(10)
   x <- object_to_bin(d)


### PR DESCRIPTION
This PR will
* Update `rrq_version` returned in `worker_info` to report only the rrq version number. Removing additional info previously returned about sha & repository