### PR TITLE
mrc-4069: drop at_front from queue submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.5
+Version: 0.6.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.6.6
+
+* Drop `at_front` argument (introduced in rrq 0.2.14), tasks can no longer jump the queue (mrc-4069)
+
 # rrq 0.6.5
 
 * Error traces now come from `rlang` and are much nicer to read (mrc-4060)

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -296,7 +296,6 @@ Queue an expression
   queue = NULL,
   separate_process = FALSE,
   timeout = NULL,
-  at_front = FALSE,
   depends_on = NULL,
   export = NULL
 )}\if{html}{\out{</div>}}
@@ -331,9 +330,6 @@ seconds. This parameter only has an effect if \code{separate_process}
 is \code{TRUE}. If given, then if the task takes longer than this
 time it will be stopped and the task status set to \code{TIMEOUT}.}
 
-\item{\code{at_front}}{Logical, if TRUE then add the task to the front
-of the queue.}
-
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks
 have been successfully run, this task will get added to the
@@ -366,7 +362,6 @@ Queue an expression
   queue = NULL,
   separate_process = FALSE,
   timeout = NULL,
-  at_front = FALSE,
   depends_on = NULL,
   export = NULL
 )}\if{html}{\out{</div>}}
@@ -396,9 +391,6 @@ details).}
 
 \item{\code{timeout}}{Optionally, a maximum allowed running time, in
 seconds (see \verb{$enqueue} for details).}
-
-\item{\code{at_front}}{Logical, if TRUE then add the task to the front
-of the queue.}
 
 \item{\code{depends_on}}{Vector or list of IDs of tasks which must have
 completed before this job can be run. Once all dependent tasks

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -448,24 +448,6 @@ test_that("Delete job after cancellation", {
 })
 
 
-test_that("task can be added to front of queue", {
-  obj <- test_rrq("myfuns.R")
-  w <- test_worker_blocking(obj)
-
-  t <- obj$enqueue(sin(0))
-  expect_equal(obj$queue_list(), t)
-  t2 <- obj$enqueue(sin(pi / 2), at_front = TRUE)
-  expect_equal(obj$queue_list(), c(t2, t))
-
-  expect_equal(unname(obj$task_status(t)), "PENDING")
-  expect_equal(unname(obj$task_status(t2)), "PENDING")
-  w$step(TRUE)
-  expect_equal(obj$task_wait(t2, 2), 1)
-  expect_equal(unname(obj$task_status(t)), "PENDING")
-  expect_equal(unname(obj$task_status(t2)), "COMPLETE")
-})
-
-
 test_that("can check task exists", {
   obj <- test_rrq("myfuns.R")
   t <- obj$enqueue(sin(0))

--- a/vignettes/rrq.Rmd
+++ b/vignettes/rrq.Rmd
@@ -411,10 +411,6 @@ obj$task_wait(id, timeout = 10)
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
 
-### Jump the queue
-
-Almost always you will want to use a first-in-first-out queueing system, which is the default that rrq supports. However when queuing you can specify `at_front = TRUE` and jump to the front of the queue.
-
 ## Running tasks in separate processes
 
 Running a task in a separate process offers some additional features at a cost of a little more overhead per task.

--- a/vignettes_src/rrq.Rmd
+++ b/vignettes_src/rrq.Rmd
@@ -339,10 +339,6 @@ obj$task_wait(id, timeout = 10)
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
 
-### Jump the queue
-
-Almost always you will want to use a first-in-first-out queueing system, which is the default that rrq supports. However when queuing you can specify `at_front = TRUE` and jump to the front of the queue.
-
 ## Running tasks in separate processes
 
 Running a task in a separate process offers some additional features at a cost of a little more overhead per task.


### PR DESCRIPTION
As discussed, this is now unused and inelegant.

~Merge after #74, contains those commits~