### PR TITLE
Make cleanup deterministic and thorough

### DIFF
--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -166,8 +166,9 @@ rrq_controller <- R6::R6Class(
     ##'   these may be faster to stop workers than "message", which will
     ##'   wait until any task is finished.
     ##'
-    ##' @param worker_stop_timeout A timeout to pass to the worker if
-    ##'   using `type = "message"`
+    ##' @param worker_stop_timeout A timeout to pass to the worker to
+    ##'   respond the request to stop. See `worker_stop`'s `timeout`
+    ##'   argument for details.
     destroy = function(delete = TRUE, worker_stop_type = "message",
                        worker_stop_timeout = 0) {
       if (!is.null(self$con)) {
@@ -895,7 +896,10 @@ rrq_controller <- R6::R6Class(
     ##' @param timeout Optional timeout; if greater than zero then we poll
     ##'   for a response from the worker for this many seconds until they
     ##'   acknowledge the message and stop (only has an effect if `type`
-    ##'   is `message`).
+    ##'   is `message`). If a timeout of greater than zero is given, then
+    ##'   for a `message`-based stop we wait up to this many seconds for the
+    ##'   worker to exit. That means that we might wait up to `2 * timeout`
+    ##'   seconds for this function to return.
     ##'
     ##' @param time_poll If `type` is `message` and `timeout` is greater
     ##'   than zero, this is the polling interval used between redis calls.
@@ -1515,6 +1519,11 @@ worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
                            delete = FALSE, timeout = timeout,
                            time_poll = time_poll,
                            progress = progress)
+      key_status <- keys$worker_status
+      when <- function() {
+        any(list_to_character(con$HMGET(key_status, worker_ids)) != "EXITED")
+      }
+      wait_timeout("Worker did not exit in time", timeout, when, time_poll)
     }
   } else if (type == "kill") {
     info <- worker_info(con, keys, worker_ids)
@@ -1535,8 +1544,12 @@ worker_stop <- function(con, keys, worker_ids = NULL, type = "message",
       stop("Not all workers are local: ",
            paste(worker_ids[!is_local], collapse = ", "))
     }
+    ## It might be possible to check to see if the process is alive -
+    ## that's easiest done with the ps package perhaps, but I think
+    ## there's a (somewhat portable) way of doing it with base R.
     tools::pskill(vnapply(info, "[[", "pid"), tools::SIGTERM)
   }
+
   invisible(worker_ids)
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -69,7 +69,7 @@ obj$worker_log_tail(n = Inf)
 For more information, see `vignette("rrq")`
 
 ```{r, include = FALSE}
-obj$destroy()
+obj$destroy(worker_stop_timeout = worker_stop_timeout)
 ```
 
 ## Installation

--- a/README.Rmd
+++ b/README.Rmd
@@ -69,7 +69,7 @@ obj$worker_log_tail(n = Inf)
 For more information, see `vignette("rrq")`
 
 ```{r, include = FALSE}
-obj$destroy(worker_stop_timeout = worker_stop_timeout)
+obj$destroy(worker_stop_timeout = 10)
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Submit work to the queue:
 ```r
 t <- obj$enqueue(runif(10))
 t
-#> [1] "6a368aa506da1aabcd264ca859fa3322"
+#> [1] "1604b9d2665fc935c5f432b0d7da4889"
 ```
 
 Query task process:
@@ -36,7 +36,7 @@ Query task process:
 
 ```r
 obj$task_status(t)
-#> 6a368aa506da1aabcd264ca859fa3322
+#> 1604b9d2665fc935c5f432b0d7da4889
 #>                        "PENDING"
 ```
 
@@ -45,8 +45,8 @@ Run tasks on workers in the background
 
 ```r
 rrq::rrq_worker_spawn(obj)
-#> Spawning 1 worker with prefix endocrinous_anemonecrab
-#> [1] "endocrinous_anemonecrab_1"
+#> Spawning 1 worker with prefix hexagonal_xenurine
+#> [1] "hexagonal_xenurine_1"
 ```
 
 Collect task results when complete
@@ -54,8 +54,8 @@ Collect task results when complete
 
 ```r
 obj$task_wait(t)
-#>  [1] 0.6429454 0.3498470 0.2804653 0.2975355 0.1308821 0.1520124 0.3212029
-#>  [8] 0.1526649 0.1589430 0.3306704
+#>  [1] 0.21934439 0.47012520 0.57837978 0.17550807 0.07085051 0.04189457
+#>  [7] 0.43439891 0.79186554 0.82606661 0.86208847
 ```
 
 Or try and retrieve them regardless of if they are complete
@@ -63,8 +63,8 @@ Or try and retrieve them regardless of if they are complete
 
 ```r
 obj$task_result(t)
-#>  [1] 0.6429454 0.3498470 0.2804653 0.2975355 0.1308821 0.1520124 0.3212029
-#>  [8] 0.1526649 0.1589430 0.3306704
+#>  [1] 0.21934439 0.47012520 0.57837978 0.17550807 0.07085051 0.04189457
+#>  [7] 0.43439891 0.79186554 0.82606661 0.86208847
 ```
 
 Query what workers have done
@@ -72,14 +72,14 @@ Query what workers have done
 
 ```r
 obj$worker_log_tail(n = Inf)
-#>                   worker_id       time       command
-#> 1 endocrinous_anemonecrab_1 1629120683         ALIVE
-#> 2 endocrinous_anemonecrab_1 1629120683    TASK_START
-#> 3 endocrinous_anemonecrab_1 1629120683 TASK_COMPLETE
+#>              worker_id       time       command
+#> 1 hexagonal_xenurine_1 1678370725         ALIVE
+#> 2 hexagonal_xenurine_1 1678370725    TASK_START
+#> 3 hexagonal_xenurine_1 1678370726 TASK_COMPLETE
 #>                            message
 #> 1
-#> 2 6a368aa506da1aabcd264ca859fa3322
-#> 3 6a368aa506da1aabcd264ca859fa3322
+#> 2 1604b9d2665fc935c5f432b0d7da4889
+#> 3 1604b9d2665fc935c5f432b0d7da4889
 ```
 
 For more information, see `vignette("rrq")`

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -252,8 +252,9 @@ the workers are on the same machine as the controller. However,
 these may be faster to stop workers than "message", which will
 wait until any task is finished.}
 
-\item{\code{worker_stop_timeout}}{A timeout to pass to the worker if
-using \code{type = "message"}}
+\item{\code{worker_stop_timeout}}{A timeout to pass to the worker to
+respond the request to stop. See \code{worker_stop}'s \code{timeout}
+argument for details.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1313,7 +1314,10 @@ all active workers will be stopped.}
 \item{\code{timeout}}{Optional timeout; if greater than zero then we poll
 for a response from the worker for this many seconds until they
 acknowledge the message and stop (only has an effect if \code{type}
-is \code{message}).}
+is \code{message}). If a timeout of greater than zero is given, then
+for a \code{message}-based stop we wait up to this many seconds for the
+worker to exit. That means that we might wait up to \code{2 * timeout}
+seconds for this function to return.}
 
 \item{\code{time_poll}}{If \code{type} is \code{message} and \code{timeout} is greater
 than zero, this is the polling interval used between redis calls.

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -119,9 +119,6 @@ test_rrq_cleanup <- function(obj, worker_stop_timeout) {
   if (is.null(worker_stop_timeout)) {
     worker_pid <- vnapply(obj$worker_info(), "[[", "pid")
     worker_is_separate <- worker_pid != Sys.getpid()
-    if (any(worker_is_separate) && !all(worker_is_separate)) {
-      warning("This test is likely to leak worker keys", immediate. = TRUE)
-    }
     worker_stop_timeout <- if (all(worker_is_separate)) 10 else 0
   }
   obj$destroy(worker_stop_timeout = worker_stop_timeout)

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -101,9 +101,18 @@ test_rrq <- function(sources = NULL, root = tempfile(), verbose = FALSE,
   obj$worker_config_save("localhost", time_poll = 1, verbose = verbose)
   obj$envir(create)
 
-  withr::defer_parent(obj$destroy())
+  withr::defer_parent(test_rrq_cleanup(obj))
 
   obj
+}
+
+
+test_rrq_cleanup <- function(obj) {
+  worker_is_separate <- vnapply(obj$worker_info(), "[[", "pid") != Sys.getpid()
+  if (any(worker_is_separate) && !all(worker_is_separate)) {
+    warning("This test is likely to leak worker keys", immediate. = TRUE)
+  }
+  obj$destroy(worker_stop_timeout = if (all(worker_is_separate)) 10 else 0)
 }
 
 

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -1,5 +1,5 @@
 test_queue_clean <- function(queue_id, delete = TRUE) {
-  invisible(rrq_clean(redux::hiredis(), queue_id, delete, "message"))
+  invisible(rrq_clean(test_hiredis(), queue_id, delete, "message"))
 }
 
 has_internet <- function() {

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -244,12 +244,9 @@ test_that("bulk tasks can be queued with dependency", {
 
 test_that("Can offload storage for bulk tasks", {
   skip_if_no_redis()
-  name <- sprintf("rrq:%s", ids::random_id())
 
   path <- tempfile()
-  rrq_configure(name, store_max_size = 100, offload_path = path)
-
-  obj <- rrq_controller$new(name)
+  obj <- test_rrq(store_max_size = 100, offload_path = path)
   obj$worker_config_save("localhost", verbose = FALSE, timeout = -1,
                          time_poll = 1, overwrite = TRUE)
 

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -1,6 +1,7 @@
 test_that("Can set and retrieve a configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
+  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
   config <- rrq_configure(name, store_max_size = 100)
   expect_equal(config, list(store_max_size = 100, offload_path = NULL))
   expect_equal(rrq_configure_read(test_hiredis(), rrq_keys_common(name)),
@@ -12,6 +13,7 @@ test_that("Reading default configuration sets it", {
   skip_if_no_redis()
   con <- test_hiredis()
   name <- sprintf("rrq:%s", ids::random_id())
+  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
   keys <- rrq_keys_common(name)
   config <- rrq_configure_read(con, keys)
   expect_equal(config, list(store_max_size = Inf, offload_path = NULL))
@@ -23,6 +25,7 @@ test_that("Reading default configuration sets it", {
 test_that("Can't set a conflicting configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
+  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
   config <- rrq_configure(name, store_max_size = 100)
   expect_error(
     rrq_configure(name, store_max_size = 101),
@@ -38,6 +41,7 @@ test_that("Can't set a conflicting configuration", {
 test_that("Can set an identical configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
+  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
   config1 <- rrq_configure(name, store_max_size = 100)
   config2 <- rrq_configure(name, store_max_size = 100)
   expect_identical(config1, config2)

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -1,7 +1,7 @@
 test_that("Can set and retrieve a configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
-  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
+  on.exit(test_hiredis()$DEL(rrq_keys(name)$config))
   config <- rrq_configure(name, store_max_size = 100)
   expect_equal(config, list(store_max_size = 100, offload_path = NULL))
   expect_equal(rrq_configure_read(test_hiredis(), rrq_keys_common(name)),
@@ -13,7 +13,7 @@ test_that("Reading default configuration sets it", {
   skip_if_no_redis()
   con <- test_hiredis()
   name <- sprintf("rrq:%s", ids::random_id())
-  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
+  on.exit(test_hiredis()$DEL(rrq_keys(name)$config))
   keys <- rrq_keys_common(name)
   config <- rrq_configure_read(con, keys)
   expect_equal(config, list(store_max_size = Inf, offload_path = NULL))
@@ -25,7 +25,7 @@ test_that("Reading default configuration sets it", {
 test_that("Can't set a conflicting configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
-  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
+  on.exit(test_hiredis()$DEL(rrq_keys(name)$config))
   config <- rrq_configure(name, store_max_size = 100)
   expect_error(
     rrq_configure(name, store_max_size = 101),
@@ -41,7 +41,7 @@ test_that("Can't set a conflicting configuration", {
 test_that("Can set an identical configuration", {
   skip_if_no_redis()
   name <- sprintf("rrq:%s", ids::random_id())
-  on.exit(redux::hiredis()$DEL(rrq_keys(name)$config))
+  on.exit(test_hiredis()$DEL(rrq_keys(name)$config))
   config1 <- rrq_configure(name, store_max_size = 100)
   config2 <- rrq_configure(name, store_max_size = 100)
   expect_identical(config1, config2)

--- a/tests/testthat/test-object-store.R
+++ b/tests/testthat/test-object-store.R
@@ -129,12 +129,11 @@ test_that("destroying a store removes everything, including offload", {
 
 
 test_that("prevent use of offload if disabled", {
-  con <- test_hiredis()
   prefix <- ids::random_id(1, 4)
   path <- tempfile()
   offload <- object_store_offload_disk$new(path)
-  s1 <- object_store$new(con, prefix, 100, NULL)
-  s2 <- object_store$new(con, prefix, 100, offload)
+  s1 <- test_store(100, offload = NULL, prefix = prefix)
+  s2 <- test_store(100, offload = offload, prefix = prefix)
 
   t <- ids::random_id()
   x <- runif(20)

--- a/tests/testthat/test-redis.R
+++ b/tests/testthat/test-redis.R
@@ -80,6 +80,7 @@ test_that("push max length", {
   con <- test_hiredis()
 
   key <- sprintf("rrq:%s", ids::random_id())
+  on.exit(con$DEL(key))
   con$RPUSH(key, c(1, 2, 3, 4))
   rpush_max_length(con, key, 5, 5)
   expect_equal(con$LRANGE(key, 0, -1), as.list(as.character(1:5)))

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -116,7 +116,7 @@ test_that("kill worker with a signal", {
   skip_if_not_installed("callr")
   skip_on_os("windows")
 
-  obj <- test_rrq()
+  obj <- test_rrq(worker_stop_timeout = 0)
   res <- obj$worker_config_save("localhost", heartbeat_period = 3)
   wid <- test_worker_spawn(obj)
 
@@ -133,7 +133,7 @@ test_that("kill worker with a signal", {
 test_that("kill worker locally", {
   skip_on_os("windows")
 
-  obj <- test_rrq()
+  obj <- test_rrq(worker_stop_timeout = 0)
   wid <- test_worker_spawn(obj)
 
   pid <- obj$worker_info(wid)[[1]]$pid
@@ -267,10 +267,9 @@ test_that("can get worker info", {
   skip_if_not_installed("callr")
   skip_on_os("windows")
 
-  obj <- test_rrq()
+  obj <- test_rrq(worker_stop_timeout = 10)
   res <- obj$worker_config_save("localhost", heartbeat_period = 3)
   wid <- test_worker_spawn(obj)
-  on.exit(obj$worker_stop(wid, "kill_local"))
 
   info <- obj$worker_info(wid)
   expect_length(info, 1)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -318,7 +318,7 @@ test_that("can't cancel nonexistant task", {
 
 
 test_that("can't cancel running in-process task", {
-  obj <- test_rrq()
+  obj <- test_rrq(worker_stop_timeout = 0)
   w <- test_worker_spawn(obj)
   t <- obj$enqueue(Sys.sleep(20))
   wait_status(t, obj)
@@ -905,10 +905,8 @@ test_that("can offload storage", {
   name <- sprintf("rrq:%s", ids::random_id())
 
   path <- tempfile()
-  rrq_configure(name, store_max_size = 100, offload_path = path)
 
-  obj <- rrq_controller$new(name)
-  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
+  obj <- test_rrq(store_max_size = 100, offload_path = path)
   a <- 10
   b <- runif(20)
   t <- obj$enqueue(sum(b) / a)
@@ -935,14 +933,8 @@ test_that("can offload storage", {
 
 
 test_that("offload storage in result", {
-  skip_if_no_redis()
-  name <- sprintf("rrq:%s", ids::random_id())
-
   path <- tempfile()
-  rrq_configure(name, store_max_size = 100, offload_path = path)
-
-  obj <- rrq_controller$new(name)
-  obj$worker_config_save("localhost", time_poll = 1, verbose = FALSE)
+  obj <- test_rrq(store_max_size = 100, offload_path = path)
   t <- obj$enqueue(rep(1, 100))
 
   w <- test_worker_blocking(obj)

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -103,7 +103,7 @@ test_that("progress - timeout", {
 
 
 test_that("status change timeout", {
-  obj <- test_rrq(name = "time")
+  obj <- test_rrq()
   t <- obj$enqueue(identity(1))
   expect_error(
     wait_status_change(obj$con, queue_keys(obj), t, TASK_PENDING, 0.01, 0.005),

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -103,7 +103,7 @@ test_that("progress - timeout", {
 
 
 test_that("status change timeout", {
-  obj <- test_rrq()
+  obj <- test_rrq(name = "time")
   t <- obj$enqueue(identity(1))
   expect_error(
     wait_status_change(obj$con, queue_keys(obj), t, TASK_PENDING, 0.01, 0.005),

--- a/tests/testthat/test-worker-spawn.R
+++ b/tests/testthat/test-worker-spawn.R
@@ -46,7 +46,7 @@ test_that("read worker process log", {
 
 
 test_that("wait for worker exit", {
-  obj <- test_rrq("myfuns.R")
+  obj <- test_rrq("myfuns.R", worker_stop_timeout = 0)
   wid <- test_worker_spawn(obj)
 
   con <- obj$con # save a copy

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -85,7 +85,7 @@ test_that("detecting output with clean exit is quiet", {
 test_that("detect killed worker (via heartbeat)", {
   skip_if_not_installed("callr")
   skip_on_covr() # possibly causing corrupt covr output
-  obj <- test_rrq("myfuns.R")
+  obj <- test_rrq("myfuns.R", worker_stop_timeout = 0)
 
   ## We need to set time_poll to be fairly fast because BLPOP is not
   ## interruptable; the interrupt will only be handled _after_ R gets
@@ -135,7 +135,7 @@ test_that("detect killed worker (via heartbeat)", {
 ## See https://github.com/mrc-ide/rrq/issues/22
 test_that("detect multiple killed workers", {
   skip_if_not_installed("callr")
-  obj <- test_rrq("myfuns.R")
+  obj <- test_rrq("myfuns.R", worker_stop_timeout = 0)
 
   res <- obj$worker_config_save("localhost", time_poll = 1,
                                 heartbeat_period = 1, verbose = FALSE)

--- a/vignettes/messages.Rmd
+++ b/vignettes/messages.Rmd
@@ -21,30 +21,30 @@ In order to do this, we're going to need a queue and a worker:
 obj <- rrq::rrq_controller$new("rrq:messages")
 logdir <- tempfile()
 worker_id <- rrq::rrq_worker_spawn(obj, logdir = logdir)
-#> Spawning 1 worker with prefix ungeometric_pitbull
+#> Spawning 1 worker with prefix suffixal_arrowana
 ```
 
 On startup the worker log contains:
 
 ```plain
-[2023-03-03 16:53:18] QUEUE default
-[2023-03-03 16:53:18] ENVIR new
-[2023-03-03 16:53:18] ALIVE
+[2023-03-09 14:04:12] QUEUE default
+[2023-03-09 14:04:12] ENVIR new
+[2023-03-09 14:04:12] ALIVE
                                  __
                 ______________ _/ /
       ______   / ___/ ___/ __ `/ /_____
      /_____/  / /  / /  / /_/ /_/_____/
  ______      /_/  /_/   \__, (_)   ______
 /_____/                   /_/     /_____/
-    worker:        ungeometric_pitbull_1
-    rrq_version:   0.6.0 [LOCAL]
+    worker:        suffixal_arrowana_1
+    rrq_version:   0.6.8
     platform:      x86_64-pc-linux-gnu (64-bit)
     running:       Ubuntu 20.04.5 LTS
     hostname:      wpia-dide300
     username:      rfitzjoh
     queue:         rrq:messages:queue:default
     wd:            /home/rfitzjoh/Documents/src/rrq/vignettes_src
-    pid:           1262841
+    pid:           725584
     redis_host:    127.0.0.1
     redis_port:    6379
     heartbeat_key: <not set>
@@ -93,16 +93,16 @@ The message id is going to be useful for getting responses:
 
 ```r
 message_id
-#> [1] "1677862398.427401"
+#> [1] "1678370652.459612"
 ```
 
 (this is derived from the current time, according to Redis which is
 the central reference point of time for the whole system).
 
 ```plain
-[2023-03-03 16:53:18] MESSAGE PING
+[2023-03-09 14:04:12] MESSAGE PING
 PONG
-[2023-03-03 16:53:18] RESPONSE PING
+[2023-03-09 14:04:12] RESPONSE PING
 ```
 
 The logfile prints:
@@ -116,10 +116,10 @@ We can access the same bits of information in the worker log:
 
 ```r
 obj$worker_log_tail(n = Inf)
-#>               worker_id       time  command message
-#> 1 ungeometric_pitbull_1 1677862398    ALIVE
-#> 2 ungeometric_pitbull_1 1677862398  MESSAGE    PING
-#> 3 ungeometric_pitbull_1 1677862398 RESPONSE    PING
+#>             worker_id       time  command message
+#> 1 suffixal_arrowana_1 1678370652    ALIVE
+#> 2 suffixal_arrowana_1 1678370652  MESSAGE    PING
+#> 3 suffixal_arrowana_1 1678370652 RESPONSE    PING
 ```
 
 This includes the `ALIVE` message as the worker comes up.
@@ -132,8 +132,8 @@ We already know that our worker has a response, but we can ask anyway:
 
 ```r
 obj$message_has_response(message_id)
-#> ungeometric_pitbull_1
-#>                  TRUE
+#> suffixal_arrowana_1
+#>                TRUE
 ```
 
 Or inversely we can as what messages a given worker has responses for:
@@ -141,7 +141,7 @@ Or inversely we can as what messages a given worker has responses for:
 
 ```r
 obj$message_response_ids(worker_id)
-#> [1] "1677862398.427401"
+#> [1] "1678370652.459612"
 ```
 
 To fetch the responses from all workers it was sent to (always
@@ -150,7 +150,7 @@ returning a named list):
 
 ```r
 obj$message_get_response(message_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "PONG"
 ```
 
@@ -159,7 +159,7 @@ or to fetch the response from a given worker:
 
 ```r
 obj$message_get_response(message_id, worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "PONG"
 ```
 
@@ -168,7 +168,7 @@ The response can be deleted by passing `delete = TRUE` to this method:
 
 ```r
 obj$message_get_response(message_id, worker_id, delete = TRUE)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "PONG"
 ```
 
@@ -177,7 +177,7 @@ after which recalling the message will throw an error:
 
 ```r
 obj$message_get_response(message_id, worker_id)
-#> Error in message_get_response(self$con, private$keys, message_id, worker_ids, : Response missing for workers: ungeometric_pitbull_1
+#> Error in message_get_response(self$con, private$keys, message_id, worker_ids, : Response missing for workers: suffixal_arrowana_1
 ```
 
 There is also a `timeout` argument that lets you wait until a response is
@@ -186,10 +186,10 @@ ready (as in `$task_wait()`).
 
 ```r
 obj$enqueue(Sys.sleep(2))
-#> [1] "e3ff668893f185f9c6e6915fb204038b"
+#> [1] "9040d13bc4eefc3927499846c45cdde7"
 message_id <- obj$message_send("PING")
 obj$message_get_response(message_id, worker_id, delete = TRUE, timeout = 10)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "PONG"
 ```
 
@@ -198,16 +198,11 @@ Looking at the log will show what went on here:
 
 ```r
 obj$worker_log_tail(n = 4)
-#>               worker_id       time       command
-#> 1 ungeometric_pitbull_1 1677862398    TASK_START
-#> 2 ungeometric_pitbull_1 1677862400 TASK_COMPLETE
-#> 3 ungeometric_pitbull_1 1677862400       MESSAGE
-#> 4 ungeometric_pitbull_1 1677862400      RESPONSE
-#>                            message
-#> 1 e3ff668893f185f9c6e6915fb204038b
-#> 2 e3ff668893f185f9c6e6915fb204038b
-#> 3                             PING
-#> 4                             PING
+#>             worker_id       time       command                          message
+#> 1 suffixal_arrowana_1 1678370653    TASK_START 9040d13bc4eefc3927499846c45cdde7
+#> 2 suffixal_arrowana_1 1678370655 TASK_COMPLETE 9040d13bc4eefc3927499846c45cdde7
+#> 3 suffixal_arrowana_1 1678370655       MESSAGE                             PING
+#> 4 suffixal_arrowana_1 1678370655      RESPONSE                             PING
 ```
 
 1. A task is received
@@ -220,11 +215,11 @@ completed, the response takes a while to come back.  Equivalently,
 from the worker log:
 
 ```plain
-[2023-03-03 16:53:18] TASK_START e3ff668893f185f9c6e6915fb204038b
-[2023-03-03 16:53:20] TASK_COMPLETE e3ff668893f185f9c6e6915fb204038b
-[2023-03-03 16:53:20] MESSAGE PING
+[2023-03-09 14:04:12] TASK_START 9040d13bc4eefc3927499846c45cdde7
+[2023-03-09 14:04:14] TASK_COMPLETE 9040d13bc4eefc3927499846c45cdde7
+[2023-03-09 14:04:14] MESSAGE PING
 PONG
-[2023-03-03 16:53:20] RESPONSE PING
+[2023-03-09 14:04:14] RESPONSE PING
 ```
 
 ## `ECHO`
@@ -237,14 +232,14 @@ response.
 ```r
 message_id <- obj$message_send("ECHO", "hello world!")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "OK"
 ```
 
 ```plain
-[2023-03-03 16:53:20] MESSAGE ECHO
+[2023-03-09 14:04:14] MESSAGE ECHO
 hello world!
-[2023-03-03 16:53:20] RESPONSE ECHO
+[2023-03-09 14:04:14] RESPONSE ECHO
 ```
 
 ## `INFO`
@@ -257,10 +252,10 @@ worker started up:
 ```r
 obj$worker_info()[[worker_id]]
 #> $worker
-#> [1] "ungeometric_pitbull_1"
+#> [1] "suffixal_arrowana_1"
 #>
 #> $rrq_version
-#> [1] "0.6.0 [LOCAL]"
+#> [1] "0.6.8"
 #>
 #> $platform
 #> [1] "x86_64-pc-linux-gnu (64-bit)"
@@ -281,7 +276,7 @@ obj$worker_info()[[worker_id]]
 #> [1] "/home/rfitzjoh/Documents/src/rrq/vignettes_src"
 #>
 #> $pid
-#> [1] 1262841
+#> [1] 725584
 #>
 #> $redis_host
 #> [1] "127.0.0.1"
@@ -303,38 +298,38 @@ field:
 
 ```r
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $ungeometric_pitbull_1
-#> $ungeometric_pitbull_1$worker
-#> [1] "ungeometric_pitbull_1"
+#> $suffixal_arrowana_1
+#> $suffixal_arrowana_1$worker
+#> [1] "suffixal_arrowana_1"
 #>
-#> $ungeometric_pitbull_1$rrq_version
-#> [1] "0.6.0 [LOCAL]"
+#> $suffixal_arrowana_1$rrq_version
+#> [1] "0.6.8"
 #>
-#> $ungeometric_pitbull_1$platform
+#> $suffixal_arrowana_1$platform
 #> [1] "x86_64-pc-linux-gnu (64-bit)"
 #>
-#> $ungeometric_pitbull_1$running
+#> $suffixal_arrowana_1$running
 #> [1] "Ubuntu 20.04.5 LTS"
 #>
-#> $ungeometric_pitbull_1$hostname
+#> $suffixal_arrowana_1$hostname
 #> [1] "wpia-dide300"
 #>
-#> $ungeometric_pitbull_1$username
+#> $suffixal_arrowana_1$username
 #> [1] "rfitzjoh"
 #>
-#> $ungeometric_pitbull_1$queue
+#> $suffixal_arrowana_1$queue
 #> [1] "rrq:messages:queue:default"
 #>
-#> $ungeometric_pitbull_1$wd
+#> $suffixal_arrowana_1$wd
 #> [1] "/home/rfitzjoh/Documents/src/rrq/vignettes_src"
 #>
-#> $ungeometric_pitbull_1$pid
-#> [1] 1262841
+#> $suffixal_arrowana_1$pid
+#> [1] 725584
 #>
-#> $ungeometric_pitbull_1$redis_host
+#> $suffixal_arrowana_1$redis_host
 #> [1] "127.0.0.1"
 #>
-#> $ungeometric_pitbull_1$redis_port
+#> $suffixal_arrowana_1$redis_port
 #> [1] 6379
 ```
 
@@ -349,7 +344,7 @@ in which queued code is evaluated in.
 ```r
 message_id <- obj$message_send("EVAL", "1 + 1")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] 2
 ```
 
@@ -365,15 +360,15 @@ The `PAUSE` / `RESUME` messages can be used to prevent workers from picking up n
 
 ```r
 obj$worker_status()
-#> daydreaming_englishpointer_1        ungeometric_pitbull_1
-#>                     "EXITED"                       "IDLE"
+#> suffixal_arrowana_1
+#>              "IDLE"
 message_id <- obj$message_send("PAUSE")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "OK"
 obj$worker_status()
-#> daydreaming_englishpointer_1        ungeometric_pitbull_1
-#>                     "EXITED"                     "PAUSED"
+#> suffixal_arrowana_1
+#>            "PAUSED"
 ```
 
 Once paused workers ignore tasks, which stay on the queue:
@@ -382,7 +377,7 @@ Once paused workers ignore tasks, which stay on the queue:
 ```r
 t <- obj$enqueue(runif(5))
 obj$task_status(t)
-#> f5ffb36505c2326e7a2eeb4539be9429
+#> 47cd554c6cba07ef1dc8093a37d26079
 #>                        "PENDING"
 ```
 
@@ -392,10 +387,10 @@ Sending a `RESUME` message unpauses the worker:
 ```r
 message_id <- obj$message_send("RESUME")
 obj$message_get_response(message_id, worker_id, timeout = 10)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "OK"
 obj$task_wait(t, 5)
-#> [1] 0.7687190 0.8578942 0.7801871 0.5873694 0.4274717
+#> [1] 0.21167910 0.89949909 0.30329825 0.09956845 0.35050015
 ```
 
 ## `SET_TIMEOUT` / `GET_TIMEOUT`
@@ -405,7 +400,7 @@ Workers will quit after being left idle for more than a certain time; this is th
 
 ```r
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #>   timeout remaining
 #>       Inf       Inf
 ```
@@ -415,7 +410,7 @@ We can set this to a finite value, in seconds:
 
 ```r
 obj$message_send_and_wait("TIMEOUT_SET", 600, worker_ids = worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #> [1] "OK"
 ```
 
@@ -426,14 +421,14 @@ Once set, the `TIMEOUT_GET` returns the length of time remaining before the work
 
 ```r
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #>   timeout remaining
-#>  600.0000  599.9371
+#>  600.0000  599.9427
 Sys.sleep(5)
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #>   timeout remaining
-#>  600.0000  594.8674
+#>  600.0000  594.8836
 ```
 
 One useful pattern is to send work to workers, then set the timeout to zero. This means that when work is complete they will exit (almost) immediately:
@@ -446,20 +441,20 @@ grp <- obj$lapply(1:5, function(x) {
 }, collect_timeout = 0)
 obj$message_send("TIMEOUT_SET", 0, worker_id)
 obj$tasks_wait(grp$task_ids)
-#> $`031a12b07f4ce1d4e4e6ed4e8ec67200`
-#> [1] 0.7483771
+#> $`16686ebcb900ef85a2a4a9f4f85652be`
+#> [1] 0.5295302
 #>
-#> $`36fa43de806307f7f76caddcc273c925`
-#> [1] 0.5262275 0.1064741
+#> $`74ddc5cabb06414225765fc8ef8bb90e`
+#> [1] 0.1678113 0.5786897
 #>
-#> $a429291aa5c1c63d3bb2e7b7ba3ebde6
-#> [1] 0.8414561 0.5551033 0.8266272
+#> $a3f5db485a3f06679e51477519524e6d
+#> [1] 0.83941635 0.73912383 0.06431491
 #>
-#> $af441b5765dc42f0d4af46e1f172724b
-#> [1] 0.7019179 0.4470992 0.8532993 0.1675170
+#> $d9f12e20247c115ee504c4931ce673cd
+#> [1] 0.5275949 0.7068059 0.5954821 0.9861208
 #>
-#> $`0033271592707f91fc34cd693c690a3c`
-#> [1] 0.3673637 0.1391727 0.2012789 0.5991020 0.9787287
+#> $`8a5a2631e45efc849d66cdf8e6a39471`
+#> [1] 0.31349435 0.03000855 0.59882556 0.08526323 0.28355152
 ```
 
 The worker will remain idle for 60s (by default) which is the length of time that one poll for work lasts, then it will exit.
@@ -467,13 +462,15 @@ The worker will remain idle for 60s (by default) which is the length of time tha
 
 ```r
 obj$worker_status(worker_id)
-#> ungeometric_pitbull_1
-#>                "IDLE"
+#> suffixal_arrowana_1
+#>              "IDLE"
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
-#> $ungeometric_pitbull_1
+#> $suffixal_arrowana_1
 #>   timeout remaining
 #>         0         0
 ```
+
+
 
 ## Messages that are supported but use via wrappers:
 

--- a/vignettes/rrq.Rmd
+++ b/vignettes/rrq.Rmd
@@ -33,7 +33,7 @@ id <- paste0("rrq:", ids::random_id(bytes = 4))
 obj <- rrq::rrq_controller$new(id)
 ```
 
-This controller uses an "identifier" (here, `id` is `rrq:5ed9e430`) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
+This controller uses an "identifier" (here, `id` is `rrq:8772cec5`) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
 
 Submit a task to the queue with the `$enqueue()` method, returning a key for that task
 
@@ -41,7 +41,7 @@ Submit a task to the queue with the `$enqueue()` method, returning a key for tha
 ```r
 t <- obj$enqueue(1 + 1)
 t
-#> [1] "d08ccc40b85bf6efe44c67e729b7e1d5"
+#> [1] "2a3b94c020670470e6ebb47fc674382f"
 ```
 
 We'll also need some worker processes to carry out our tasks. Here, we'll spawn two for now (see the section below on alternatives to this)
@@ -49,8 +49,8 @@ We'll also need some worker processes to carry out our tasks. Here, we'll spawn 
 
 ```r
 rrq::rrq_worker_spawn(obj, 2)
-#> Spawning 2 workers with prefix hulkingsuperstrong_tench
-#> [1] "hulkingsuperstrong_tench_1" "hulkingsuperstrong_tench_2"
+#> Spawning 2 workers with prefix superserious_prairiedog
+#> [1] "superserious_prairiedog_1" "superserious_prairiedog_2"
 ```
 
 Retrieve the result, polling if needed:
@@ -126,7 +126,7 @@ Initially the task has status `RUNNING` (it will be `PENDING` *very* briefly):
 
 ```r
 obj$task_status(t)
-#> 969c9c71edc0081a688cc14ddfcb4bf8
+#> 09c698b77112d45bf33eee5c3633136d
 #>                        "RUNNING"
 ```
 
@@ -136,7 +136,7 @@ Then after a couple of seconds it will complete (we pad this out here so that it
 ```r
 Sys.sleep(3)
 obj$task_result(t)
-#> [1] 0.9715793
+#> [1] 0.1871163
 ```
 
 The basic task lifecycle is this:
@@ -156,7 +156,7 @@ t <- obj$enqueue({
   runif(1)
 })
 obj$task_wait(t)
-#> [1] 0.08404215
+#> [1] 0.56998
 ```
 
 The polling interval here is 1 second by default, but if the task completes within that period it will still be returned as soon as it is complete (the interval is just the time between progress bar updates and the period where an interrupt would be caught to cancel the wait).
@@ -166,9 +166,9 @@ Once a task is complete, `$task_wait` and `$task_result` are equivalent
 
 ```r
 obj$task_wait(t)
-#> [1] 0.08404215
+#> [1] 0.56998
 obj$task_result(t)
-#> [1] 0.08404215
+#> [1] 0.56998
 ```
 
 ## Configuring the worker environment
@@ -207,15 +207,15 @@ By default, this will notify all running workers to update their environment. No
 
 ```r
 obj$worker_log_tail(n = 4)
-#>                    worker_id       time  command message
-#> 1 hulkingsuperstrong_tench_1 1677862388  MESSAGE REFRESH
-#> 2 hulkingsuperstrong_tench_2 1677862388  MESSAGE REFRESH
-#> 3 hulkingsuperstrong_tench_1 1677862388    ENVIR     new
-#> 4 hulkingsuperstrong_tench_2 1677862388    ENVIR     new
-#> 5 hulkingsuperstrong_tench_1 1677862388    ENVIR  create
-#> 6 hulkingsuperstrong_tench_2 1677862388    ENVIR  create
-#> 7 hulkingsuperstrong_tench_1 1677862388 RESPONSE REFRESH
-#> 8 hulkingsuperstrong_tench_2 1677862388 RESPONSE REFRESH
+#>                   worker_id       time  command message
+#> 1 superserious_prairiedog_1 1678370556  MESSAGE REFRESH
+#> 2 superserious_prairiedog_2 1678370556  MESSAGE REFRESH
+#> 3 superserious_prairiedog_1 1678370556    ENVIR     new
+#> 4 superserious_prairiedog_2 1678370556    ENVIR     new
+#> 5 superserious_prairiedog_1 1678370556    ENVIR  create
+#> 6 superserious_prairiedog_2 1678370556    ENVIR  create
+#> 7 superserious_prairiedog_2 1678370556 RESPONSE REFRESH
+#> 8 superserious_prairiedog_1 1678370556 RESPONSE REFRESH
 ```
 
 Now our workers have picked up our functions we can start using them:
@@ -237,6 +237,8 @@ create <- function(env) {
 ```
 
 This approach would also allow you do do something like read an rds or Rdata file containing a large object that you want every worker to have a copy of.
+
+
 
 ## Scheduling options
 
@@ -303,7 +305,7 @@ The status of the first task will be `PENDING`, per usual:
 
 ```r
 obj$task_status(id)
-#> d1209f2a22aa554d712ff9fda5b19cfd
+#> d5564e19903a8f1d161eae656665f50c
 #>                        "PENDING"
 ```
 
@@ -312,14 +314,14 @@ however, the group of tasks submitted as part of the `$lapply` call will be `DEF
 
 ```r
 obj$task_status(id_use$task_ids)
-#> 063fd1775fa92b27577c1c499270d56b 0628ec53299f634d52acf8e8903b4643
+#> a287f7b0ba9038898e67b1823c21a2f9 dcd58bc1ff42e5ecd8f920f793c06eca
 #>                       "DEFERRED"                       "DEFERRED"
-#> a341ad8c3d44fd6f0da1736251b5798b 4b182cb4d0bdaf0d57a9ffe24ae6d05e
+#> 9a2b73f7f623b14e9b65d425d2646b3c 8f57479ebaa6eb9b8d612275bc06dfa5
 #>                       "DEFERRED"                       "DEFERRED"
-#> d415a3ad83a2751d8a04333447f8b326
+#> be22405cacbc162fdec9759f422432dd
 #>                       "DEFERRED"
 obj$queue_list()
-#> [1] "d1209f2a22aa554d712ff9fda5b19cfd"
+#> [1] "d5564e19903a8f1d161eae656665f50c"
 ```
 
 Once the first task is processed by a worker, the status changes:
@@ -329,19 +331,19 @@ Once the first task is processed by a worker, the status changes:
 
 ```r
 obj$task_status(id)
-#> d1209f2a22aa554d712ff9fda5b19cfd
+#> d5564e19903a8f1d161eae656665f50c
 #>                       "COMPLETE"
 obj$task_status(id_use$task_ids)
-#> 063fd1775fa92b27577c1c499270d56b 0628ec53299f634d52acf8e8903b4643
+#> a287f7b0ba9038898e67b1823c21a2f9 dcd58bc1ff42e5ecd8f920f793c06eca
 #>                        "PENDING"                        "PENDING"
-#> a341ad8c3d44fd6f0da1736251b5798b 4b182cb4d0bdaf0d57a9ffe24ae6d05e
+#> 9a2b73f7f623b14e9b65d425d2646b3c 8f57479ebaa6eb9b8d612275bc06dfa5
 #>                        "PENDING"                        "PENDING"
-#> d415a3ad83a2751d8a04333447f8b326
+#> be22405cacbc162fdec9759f422432dd
 #>                        "PENDING"
 obj$queue_list()
-#> [1] "d415a3ad83a2751d8a04333447f8b326" "063fd1775fa92b27577c1c499270d56b"
-#> [3] "4b182cb4d0bdaf0d57a9ffe24ae6d05e" "0628ec53299f634d52acf8e8903b4643"
-#> [5] "a341ad8c3d44fd6f0da1736251b5798b"
+#> [1] "be22405cacbc162fdec9759f422432dd" "dcd58bc1ff42e5ecd8f920f793c06eca"
+#> [3] "a287f7b0ba9038898e67b1823c21a2f9" "9a2b73f7f623b14e9b65d425d2646b3c"
+#> [5] "8f57479ebaa6eb9b8d612275bc06dfa5"
 ```
 
 At this point the tasks will proceed through the queue as usual.
@@ -351,6 +353,8 @@ Points to note here:
 * The deferred tasks cannot access the queued result of the blocking task (see above)
 * The deferred tasks will be added to the *front* of the queue after they become undeferred
 * The deferred tasks can't be queued until the blocking tasks have returned an id
+
+
 
 ### Multiple queues
 
@@ -367,7 +371,7 @@ obj <- rrq::rrq_controller$new(id)
 obj$worker_config_save("short", queue = "short")
 obj$worker_config_save("all", queue = c("short", "long"))
 obj$worker_config_list()
-#> [1] "all"       "short"     "localhost"
+#> [1] "short"     "all"       "localhost"
 ```
 
 Above, we create two configurations: "short" which just listens on the queue `short`, and `all` which listens both on the short and long task queues (note that both these workers will also listen on the default queue).
@@ -375,11 +379,11 @@ Above, we create two configurations: "short" which just listens on the queue `sh
 
 ```r
 rrq::rrq_worker_spawn(obj, worker_config = "short")
-#> Spawning 1 worker with prefix wellfreckled_mole
-#> [1] "wellfreckled_mole_1"
+#> Spawning 1 worker with prefix subpericranial_harvestmen
+#> [1] "subpericranial_harvestmen_1"
 rrq::rrq_worker_spawn(obj, worker_config = "all")
-#> Spawning 1 worker with prefix sinister_guineafowl
-#> [1] "sinister_guineafowl_1"
+#> Spawning 1 worker with prefix xenophobic_corydorascatfish
+#> [1] "xenophobic_corydorascatfish_1"
 ```
 
 We can then submit a long task to the worker:
@@ -396,8 +400,8 @@ After the workers have had the ability to pick up work, our "short" worker is st
 
 ```r
 obj$worker_status()
-#>   wellfreckled_mole_1 sinister_guineafowl_1
-#>                "IDLE"                "BUSY"
+#>   subpericranial_harvestmen_1 xenophobic_corydorascatfish_1
+#>                        "IDLE"                        "BUSY"
 ```
 
 So we can submit tasks to this short queue and have them processed
@@ -406,10 +410,12 @@ So we can submit tasks to this short queue and have them processed
 ```r
 id <- obj$enqueue(runif(1), queue = "short")
 obj$task_wait(id, timeout = 10)
-#> [1] 0.5917732
+#> [1] 0.1623471
 ```
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
+
+
 
 ## Running tasks in separate processes
 
@@ -450,8 +456,8 @@ then we create the queue object as normal (and spawn a worker so that we can use
 ```r
 obj <- rrq::rrq_controller$new(id)
 rrq::rrq_worker_spawn(obj, 1)
-#> Spawning 1 worker with prefix spotty_dore
-#> [1] "spotty_dore_1"
+#> Spawning 1 worker with prefix flaming_swellfish
+#> [1] "flaming_swellfish_1"
 ```
 
 It's not hard at all to get to 1KB of data, we can do that by simulating a big pile of random numbers:
@@ -468,8 +474,10 @@ Once the task has finished, data will be stored on disk below the path given abo
 
 ```r
 dir(path)
-#> [1] "fd3e54c334660e2599c95f0bb4a1787c457e847d650678968ad2422a794f9260"
+#> [1] "04622c6fe8be0e45be61bb51ce3d3c63"
 ```
+
+
 
 This keeps the larger objects out of the database.
 
@@ -547,37 +555,37 @@ Then, launch a worker
 
 ```r
 rrq::rrq_worker_spawn(obj, 1)
-#> Spawning 1 worker with prefix underaverage_australianshelduck
-#> [1] "underaverage_australianshelduck_1"
+#> Spawning 1 worker with prefix scattered_buffalo
+#> [1] "scattered_buffalo_1"
 ```
 
 Our worker will print information indicating that the heartbeat is enabled (use `obj$worker_process_log()`)
 
 
 ```
-#> [2023-03-03 16:53:10] QUEUE default
-#> [2023-03-03 16:53:10] ENVIR new
-#> [2023-03-03 16:53:10] HEARTBEAT rrq:57b6da36:worker:underaverage_australianshelduck_1:heartbeat
-#> [2023-03-03 16:53:10] HEARTBEAT OK
-#> [2023-03-03 16:53:10] ALIVE
+#> [2023-03-09 14:02:40] QUEUE default
+#> [2023-03-09 14:02:40] ENVIR new
+#> [2023-03-09 14:02:40] HEARTBEAT rrq:ec0e29cf:worker:scattered_buffalo_1:heartbeat
+#> [2023-03-09 14:02:40] HEARTBEAT OK
+#> [2023-03-09 14:02:40] ALIVE
 #>                                  __
 #>                 ______________ _/ /
 #>       ______   / ___/ ___/ __ `/ /_____
 #>      /_____/  / /  / /  / /_/ /_/_____/
 #>  ______      /_/  /_/   \__, (_)   ______
 #> /_____/                   /_/     /_____/
-#>     worker:        underaverage_australianshelduck_1
-#>     rrq_version:   0.6.0 [LOCAL]
+#>     worker:        scattered_buffalo_1
+#>     rrq_version:   0.6.8
 #>     platform:      x86_64-pc-linux-gnu (64-bit)
 #>     running:       Ubuntu 20.04.5 LTS
 #>     hostname:      wpia-dide300
 #>     username:      rfitzjoh
-#>     queue:         rrq:57b6da36:queue:default
+#>     queue:         rrq:ec0e29cf:queue:default
 #>     wd:            /home/rfitzjoh/Documents/src/rrq/vignettes_src
-#>     pid:           1262778
+#>     pid:           724795
 #>     redis_host:    127.0.0.1
 #>     redis_port:    6379
-#>     heartbeat_key: rrq:57b6da36:worker:underaverage_australianshelduck_1:heartbeat
+#>     heartbeat_key: rrq:ec0e29cf:worker:scattered_buffalo_1:heartbeat
 ```
 
 We also have a heartbeat key here that we can inspect:
@@ -588,7 +596,7 @@ info <- obj$worker_info()[[1]]
 obj$con$EXISTS(info$heartbeat_key)
 #> [1] 1
 obj$con$PTTL(info$heartbeat_key) # in milliseconds
-#> [1] 5955
+#> [1] 5954
 ```
 
 We queue some slow job onto the worker:
@@ -632,7 +640,7 @@ So far as `rrq` is concerned, at this point your task is still running
 
 ```r
 obj$task_status(t)
-#> 0c555f54f1057b02001333c144884cd8
+#> d38250bbe918a905ce82991d05b38c51
 #>                        "RUNNING"
 ```
 
@@ -642,9 +650,9 @@ Handling this situation is still completely manual.  You can detect lost workers
 ```r
 obj$worker_detect_exited()
 #> Lost 1 worker:
-#>   - underaverage_australianshelduck_1
+#>   - scattered_buffalo_1
 #> Orphaning 1 task:
-#>   - 0c555f54f1057b02001333c144884cd8
+#>   - d38250bbe918a905ce82991d05b38c51
 ```
 
 this will also "orphan" the task
@@ -652,13 +660,19 @@ this will also "orphan" the task
 
 ```r
 obj$task_status(t)
-#> 0c555f54f1057b02001333c144884cd8
+#> d38250bbe918a905ce82991d05b38c51
 #>                           "DIED"
 ```
 
 Any tasks that were dependent on this task will now be marked as `IMPOSSIBLE`.
 
 In a future version we will support automatic re-queuing of jobs assigned to disappeared workers.
+
+
+
+```r
+obj$destroy()
+```
 
 ## Getting a Redis server
 

--- a/vignettes_src/messages.Rmd
+++ b/vignettes_src/messages.Rmd
@@ -307,6 +307,10 @@ obj$worker_status(worker_id)
 obj$message_send_and_wait("TIMEOUT_GET", worker_ids = worker_id)
 ```
 
+```{r, include = FALSE}
+obj$destroy(worker_stop_timeout = 10)
+```
+
 ## Messages that are supported but use via wrappers:
 
 There are other methods that are typically used via methods on the [`rrq::rrq_controller`] object.

--- a/vignettes_src/rrq.Rmd
+++ b/vignettes_src/rrq.Rmd
@@ -207,6 +207,10 @@ create <- function(env) {
 
 This approach would also allow you do do something like read an rds or Rdata file containing a large object that you want every worker to have a copy of.
 
+```{r, include = FALSE}
+obj$destroy(worker_stop_timeout = 10)
+```
+
 ## Scheduling options
 
 The `rrq` package does not aspire to be a fully fledged scheduler, but sometimes a little more control than first-in-first-out is required. There are a few options available that allow the user to control how tasks are run when needed. These involve:
@@ -291,6 +295,10 @@ Points to note here:
 * The deferred tasks will be added to the *front* of the queue after they become undeferred
 * The deferred tasks can't be queued until the blocking tasks have returned an id
 
+```{r, include = FALSE}
+obj$destroy()
+```
+
 ### Multiple queues
 
 Sometimes it is useful to have different workers listen on different queues. For example, you may have workers on different machines with different capabilities (e.g., a machine with a GPU or high memory). You may have tasks that are expected to take quite a long time but want some workers to monitor a fast queue with short lived tasks.
@@ -338,6 +346,12 @@ obj$task_wait(id, timeout = 10)
 ```
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
+
+```{r, include = FALSE}
+obj$worker_stop(type = "kill_local")
+Sys.sleep(1)
+obj$destroy()
+```
 
 ## Running tasks in separate processes
 
@@ -392,6 +406,10 @@ Once the task has finished, data will be stored on disk below the path given abo
 
 ```{r}
 dir(path)
+```
+
+```{r, include = FALSE}
+obj$destroy(worker_stop_timeout = 10)
 ```
 
 This keeps the larger objects out of the database.
@@ -537,6 +555,11 @@ obj$task_status(t)
 Any tasks that were dependent on this task will now be marked as `IMPOSSIBLE`.
 
 In a future version we will support automatic re-queuing of jobs assigned to disappeared workers.
+
+
+```{r}
+obj$destroy()
+```
 
 ## Getting a Redis server
 


### PR DESCRIPTION
This PR updates the test and vignette running to ensure that no remaining R processes or keys are left in the redis database. This was a bit of a fiddle to do! I was going to work on mrc-4065 (clean up workers) but feel like this was really needed first.