### PR TITLE
Helper to verify that locally installed rrq is suitable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.12
+Version: 0.6.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/helper-rrq.R
+++ b/tests/testthat/helper-rrq.R
@@ -205,4 +205,3 @@ options(
   ## Cap the task wait timeout so that don't lock up CI with
   ## hard-to-track-down bugs
   rrq.timeout_task_wait = 20)
-


### PR DESCRIPTION
As discussed last week, adds a little helper to the tests to skip if the installed version does not match on the version number.