### PR TITLE
Add new task_info method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.13
+Version: 0.6.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rrq 0.6.14
+
+* New `$task_info` method to retrieve more detailed information about where a task was run (mrc-4058)
+
 # rrq 0.6.13
 
 * Argument standardisation for timeouts, with changes:

--- a/R/keys.R
+++ b/R/keys.R
@@ -33,6 +33,7 @@ rrq_keys_common <- function(queue_id) {
        task_timeout   = sprintf("%s:task:timeout",   queue_id),
        task_progress  = sprintf("%s:task:progress",  queue_id),
        task_result    = sprintf("%s:task:result",    queue_id),
+       task_pid       = sprintf("%s:task:pid",       queue_id),
 
        ## This is the key where we store the extra complete key we
        ## might push to at.

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,10 @@ blank <- function(n) {
   if (is.null(a)) b else a
 }
 
+`%&&%` <- function(a, b) { # nolint
+  if (is.null(a)) a else b
+}
+
 
 sys_getenv <- function(x) {
   ret <- Sys.getenv(x)

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -55,6 +55,8 @@ worker_run_task_separate_process <- function(task, worker, private) {
     package = "rrq",
     supervise = TRUE)
 
+  con$HSET(keys$task_pid, task_id, px$get_pid())
+
   timeout_task <- con$HGET(keys$task_timeout, task_id)
   if (!is.null(timeout_task)) {
     timeout_task <- Sys.time() + as.numeric(timeout_task)

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -150,6 +150,7 @@ after creation.}
 \item \href{#method-rrq_controller-task_delete}{\code{rrq_controller$task_delete()}}
 \item \href{#method-rrq_controller-task_cancel}{\code{rrq_controller$task_cancel()}}
 \item \href{#method-rrq_controller-task_data}{\code{rrq_controller$task_data()}}
+\item \href{#method-rrq_controller-task_info}{\code{rrq_controller$task_info()}}
 \item \href{#method-rrq_controller-task_times}{\code{rrq_controller$task_times()}}
 \item \href{#method-rrq_controller-queue_length}{\code{rrq_controller$queue_length()}}
 \item \href{#method-rrq_controller-queue_list}{\code{rrq_controller$queue_list()}}
@@ -1122,6 +1123,28 @@ Fetch internal data about a task from Redis
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{task_id}}{The id of the task}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-rrq_controller-task_info"></a>}}
+\if{latex}{\out{\hypertarget{method-rrq_controller-task_info}{}}}
+\subsection{Method \code{task_info()}}{
+Return information about a task. This currently
+includes information about where a task is (or was) running,
+but will expand in future. The format of the output here is
+subject to change (and will probably get a nice print method)
+but the values present in the output will be included in any
+future update.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_info(task_id)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{task_id}}{The id of the task to fetch information about}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
Pretty simple at first, just returning a few things in a list. This *will* expand because it would be nice to return information about the dependency structure and retry chain here, but starting simple for now