### PR TITLE
Add fault tolerance vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.14
+Version: 0.6.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,14 @@ vignettes/messages.Rmd: vignettes_src/messages.Rmd
 	sed -i.bak 's/[[:space:]]*$$//' $@
 	rm -f $@.bak
 
-vignettes: vignettes/rrq.Rmd vignettes/messages.Rmd
+vignettes/fault-tolerance.Rmd: vignettes_src/fault-tolerance.Rmd
+	mkdir -p vignettes
+	cd vignettes_src && ${RSCRIPT} -e 'knitr::knit("fault-tolerance.Rmd")'
+	mv vignettes_src/fault-tolerance.md $@
+	sed -i.bak 's/[[:space:]]*$$//' $@
+	rm -f $@.bak
+
+vignettes: vignettes/rrq.Rmd vignettes/messages.Rmd vignettes/fault-tolerance.Rmd
 	Rscript -e 'library(methods); devtools::build_vignettes()'
 
 .PHONY: all test document install vignettes

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1044,7 +1044,7 @@ rrq_controller <- R6::R6Class(
 
     ##' @description Detects exited workers through a lapsed heartbeat
     worker_detect_exited = function() {
-      worker_detect_exited(self)
+      worker_detect_exited(self$con, private$keys, private$store)
     },
 
     ##' @description Return the contents of a worker's process log, if

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -129,6 +129,10 @@ test_that("detect killed worker (via heartbeat)", {
 
   expect_silent(res <- obj$worker_detect_exited())
   expect_null(res)
+
+  expect_equal(obj$task_status(t), set_names(TASK_DIED, t))
+  expect_equal(obj$task_result(t),
+               worker_task_failed(TASK_DIED, obj$queue_id, t))
 })
 
 
@@ -164,6 +168,14 @@ test_that("detect multiple killed workers", {
 
   expect_silent(res <- obj$worker_detect_exited())
   expect_null(res)
+
+  expect_equal(obj$task_status(t1), set_names(TASK_DIED, t1))
+  expect_equal(obj$task_result(t1),
+               worker_task_failed(TASK_DIED, obj$queue_id, t1))
+
+  expect_equal(obj$task_status(t2), set_names(TASK_DIED, t2))
+  expect_equal(obj$task_result(t2),
+               worker_task_failed(TASK_DIED, obj$queue_id, t2))
 })
 
 

--- a/vignettes/fault-tolerance.Rmd
+++ b/vignettes/fault-tolerance.Rmd
@@ -1,0 +1,343 @@
+---
+title: "Fault tolerance"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Fault tolerance}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+
+
+In a perfect world, nothing would fail, and this vignette would not be needed. But here we are.
+
+When you run tasks within a single process and things go wrong, you know immediately you see it happen. With a queuing system like rrq it's less obvious when something bad has happened because the task is running on another process, possibly on a different machine!
+
+* Plain errors are the simplest sort of fault to recover from. Your task throws an error, `rrq` picks this up and marks the task as errored, and moves on to the next thing. You can then see that this error has happened as its status.
+* If your task crashes the process it can take out the worker (depending on how you have configured rrq; see below). In this case nothing updates the task status, and your task appears to stay running forever. This situation also arises if your process is killed by the operating system (e.g., out of memory) or via some other condition (e.g., an administrator terminating the process).
+* If your task is running on another machine and that machine becomes unreachable (switched off, disconnects from the network, etc) your task will never appear to finish.
+
+This vignette discusses how you can mitigate against and recover from these sorts of issues. We start with the expected errors and build up to considerations for creating a fault tolerant queue.
+
+## Error handling
+
+We start with the simplest sort of fault, and can just as easily happen locally as remotely with `rrq`. In this case the handling is fairly well defined and there's not much you need to do. This section is not really "fault tolerance" at all, but simply how rrq handles errors and what you can do about it.
+
+Consider this simple function which would fit a linear model between two variables:
+
+```r
+fit_model <- function(x, y) {
+  lm(y ~ x)
+}
+```
+
+
+```r
+obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
+obj$envir(rrq::rrq_envir(sources = "fault.R"))
+rrq::rrq_worker_spawn(obj)
+#> Spawning 1 worker with prefix veryveryveryflying_irukandjijellyfish
+#> [1] "veryveryveryflying_irukandjijellyfish_1"
+```
+
+In the happy case, everything works as expected:
+
+
+```r
+x <- runif(5)
+y <- 2 * x + rnorm(length(x), 0, 0.2)
+t <- obj$enqueue(fit_model(x, y))
+obj$task_wait(t, 10)
+#>
+#> Call:
+#> lm(formula = y ~ x)
+#>
+#> Coefficients:
+#> (Intercept)            x
+#>      0.3131       1.2989
+obj$task_status(t)
+#> 6804dc79e94909b3143af5a856afdd9b
+#>                       "COMPLETE"
+```
+
+But if we provide invalid input, the task will error:
+
+
+```r
+t <- obj$enqueue(fit_model(x, NULL))
+obj$task_wait(t, 10)
+#> <rrq_task_error>
+#>   from:   model.frame.default(formula = y ~ x, drop.unused.levels = TRUE)
+#>   error:  invalid type (NULL) for variable 'y'
+#>   queue:  rrq:81b322b2
+#>   task:   9cb24b2a17ee248d5c129d3128a7af39
+#>   status: ERROR
+#>   * To throw this error, use stop() with it
+#>   * This error has a stack trace, use '$trace' to see it
+```
+
+The first thing to note here is that the task does not throw an error when you fetch the result, either via `task_wait` as above, or via `task_result`:
+
+
+```r
+r <- obj$task_result(t)
+r
+#> <rrq_task_error>
+#>   from:   model.frame.default(formula = y ~ x, drop.unused.levels = TRUE)
+#>   error:  invalid type (NULL) for variable 'y'
+#>   queue:  rrq:81b322b2
+#>   task:   9cb24b2a17ee248d5c129d3128a7af39
+#>   status: ERROR
+#>   * To throw this error, use stop() with it
+#>   * This error has a stack trace, use '$trace' to see it
+```
+
+However, the result will be an object of `rrq_task_error` which you can test for using `inherits`:
+
+
+```r
+inherits(r, "rrq_task_error")
+#> [1] TRUE
+```
+
+The default behaviour of `rrq` is not to error when fetching a task as that would require that you use `tryCatch` everywhere where you retrieve tasks that might have failed, and because errors are often interesting themselves. For example, `rrq_task_error` objects include stack traces alongside the error:
+
+
+```r
+r$trace
+#>      ▆
+#>   1. ├─base::tryCatch(...)
+#>   2. │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
+#>   3. │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+#>   4. │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
+#>   5. ├─base::withCallingHandlers(...)
+#>   6. ├─base::eval(expr, envir)
+#>   7. │ └─base::eval(expr, envir)
+#>   8. │   └─fit_model(x, NULL)
+#>   9. │     ├─stats::lm(y ~ x)
+#>  10. │     │ └─base::eval(mf, parent.frame())
+#>  11. │     │   └─base::eval(mf, parent.frame())
+#>  12. │     ├─stats::model.frame(formula = y ~ x, drop.unused.levels = TRUE)
+#>  13. │     └─stats::model.frame.default(formula = y ~ x, drop.unused.levels = TRUE)
+#>  14. └─base::.handleSimpleError(...)
+#>  15.   └─rrq (local) h(simpleError(msg, call))
+```
+
+These are `rlang` stack traces, which are somewhat richer than those produced by `traceback()`, containing the same set of stacks but arranged in a tree. See the [documentation there](https://rlang.r-lib.org/reference/trace_back.html) for details. This error object will also include any warnings captured while the task ran.
+
+Objects of class `rrq_task_error` inherit from `error` and `condition` so, once thrown, will behave as expected in programs using errors for flow control (e.g., with `tryCatch`); you can throw them yourself with  `stop()`:
+
+
+```r
+stop(r)
+#> Error in model.frame.default(formula = y ~ x, drop.unused.levels = TRUE): invalid type (NULL) for variable 'y'
+```
+
+You can also change the default behaviour to error on failure by passing  `error = TRUE` to any of `$task_result()`, `$task_wait()`, `$tasks_result()` or `$tasks_wait()`, which will immediately rethrow the error in your R session (your program could then stop or you could again catch it with `tryCatch`):
+
+
+```r
+obj$task_result(t, error = TRUE)
+#> Error in model.frame.default(formula = y ~ x, drop.unused.levels = TRUE): invalid type (NULL) for variable 'y'
+```
+
+This process is unchanged if the task is run in a separate process (with `separate_process = TRUE` passed to `enqueue`), with the same status and return type, and with the trace information available after failure.
+
+## Increasing resiliance via separate processes
+
+Running tasks in separate processes (e.g., `obj$enqueue(mytask(), separate_process = TRUE)`) is the simplest way of making things more resiliant because this creates a layer of isolation between the worker and the task. If your task crashes R (e.g., a segmentation fault due to a bug in your C/C++ code) or is killed by the operating system then the worker process survives and can update the keys in Redis directly to advertise this fact. This is geerally much nicer than when the worker dies and the task status cannot be updated.
+
+The downside of using separate processes is that it is much slower; compare the time taken to queue, run an retrieve a trivial task run in the same worker process (look at the `elapsed` entry)
+
+
+```r
+system.time(
+  obj$task_wait(obj$enqueue(identity(1)), 10))
+#>    user  system elapsed
+#>   0.001   0.000   0.003
+```
+
+with the same task run in a separate process on the worker
+
+
+```r
+system.time(
+  obj$task_wait(obj$enqueue(identity(1), separate_process = TRUE), 10))
+#>    user  system elapsed
+#>   0.001   0.000   0.234
+```
+
+We expect this difference to be ~100 fold in local workers. Almost all the cost is due to the overhead of starting and terminating a fresh R session. If your queue uses a lot of packages there will be additional overhead here too as these are loaded. However, this cost is fixed and will decrease as a fraction of the total running time as the running time of your task increases. So for long-running tasks the additional safety of separate processes is probably worthwhile. For smaller tasks you may want to make sure you run a heartbeat process so that you can handle failures via that route.
+
+Consider running some long running job; this one simply sleeps for an hour
+
+
+```r
+t <- obj$enqueue(Sys.sleep(3600), separate_process = TRUE)
+```
+
+
+
+To simulate the process crashing, we've killed it. Because we have queued this on a separate process we can use `$task_info()` to fetch the process id (PID) of the process that the task is running in (this is different to that of the worker).
+
+
+```r
+info <- obj$task_info(t)
+tools::pskill(info$pid)
+```
+
+
+
+Because the task was run in a separate process, our worker could detect that the task has died unexpectedly:
+
+
+```r
+obj$task_status(t)
+#> 66b2d847d2828e71f95bd1e5d42460e4
+#>                           "DIED"
+```
+
+This is different to the error status in the previous section (that was ERROR). Note that if we had not run the task in a separate process the task status would be unchanged as RUNNING) because nothing could ever update the task status!
+
+Retrieving the result has similar behaviour to the error case; we don't throw but instead return an object of class `rrq_task_error` (which also inherits from `error` and `condition`). However, this time there's really not much extra information in the error:
+
+
+```r
+r <- obj$task_result(t)
+r
+#> <rrq_task_error>
+#>   error:  Task not successful: DIED
+#>   queue:  rrq:81b322b2
+#>   task:   66b2d847d2828e71f95bd1e5d42460e4
+#>   status: DIED
+#>   * To throw this error, use stop() with it
+```
+
+There's also no trace available
+
+
+```r
+r$trace
+#> NULL
+```
+
+## Loss of workers
+
+In this section we outline what you can do about unexplained and unreported failures in your task, or loss of workers. This will typically be that your worker has crashed (due to your task crashing it perhaps), killed (e.g., by the operating system or an administrator) or the loss of the machine that it is working on.
+
+In order to enable fault tolerance for this sort of issue, you first need to enable a "heatbeat" on the worker processes. This is a second process on each worker that periodically writes to the Redis database on a key that will expire in a time slightly longer than that period, in effect making a [dead man's switch](https://en.wikipedia.org/wiki/Dead_man%27s_switch) - see `rrq::rrq_heartbeat` for details. So if the worker process dies for any reason, then after a while we'll detect that as its key has expired. We can then take some action.
+
+
+
+To enable the heartbeat, save a worker configuration before starting a worker:
+
+
+```r
+obj$worker_config_save("localhost", heartbeat_period = 3, overwrite = TRUE)
+```
+
+When you spawn a worker it will pick up this configuration, and we'll be able to detect if it has died.
+
+
+```r
+w <- rrq::rrq_worker_spawn(obj)
+#> Spawning 1 worker with prefix capillary_irishterrier
+```
+
+In order to simulate the loss of the worker, we need its [process id (PID)](https://en.wikipedia.org/wiki/Process_identifier), which we can get from the controller object:
+
+
+```r
+w_pid <- obj$worker_info()[[w]]$pid
+w_pid
+#> [1] 1446751
+```
+
+Now, we can queue some long running process, which this worker will start:
+
+
+```r
+t <- obj$enqueue(Sys.sleep(3600))
+```
+
+
+
+The worker wil pick the task up fairly quickly, and the status will change to `RUNNING`:
+
+
+```r
+obj$task_status(t)
+#> 70db5d215affb4ba0c155c05d66803ce
+#>                        "RUNNING"
+obj$worker_status(w)
+#> capillary_irishterrier_1
+#>                   "BUSY"
+```
+
+<!-- ```{r} -->
+<!-- Sys.sleep(1) -->
+<!-- ``` -->
+
+We kill the worker (simulating the job crashing, or the machine turning off, etc):
+
+
+```r
+tools::pskill(w_pid)
+```
+
+Because the worker has been killed, it can't write to redis to tell us that the task can't be completed, so this status will never change:
+
+
+```r
+obj$task_status(t)
+#> 70db5d215affb4ba0c155c05d66803ce
+#>                        "RUNNING"
+obj$worker_status(w)
+#> capillary_irishterrier_1
+#>                   "BUSY"
+```
+
+The heartbeat will persist for 3 times the period given above (this multiplier is not configurable and while any number greater than 1 should be OK, we picked this as it allows for occasional network connectivity issues or slowness on the node - we may reduce it in a future version). This means that after 9s (3 * 3s) the key will have expired:
+
+
+```r
+Sys.sleep(10)
+```
+
+We can then use the `worker_detect_exited()` method to clean up
+
+
+```r
+obj$worker_detect_exited()
+#> Lost 1 worker:
+#>   - capillary_irishterrier_1
+#> Orphaning 1 task:
+#>   - 70db5d215affb4ba0c155c05d66803ce
+```
+
+At this point, the statuses of our task and worker are correct:
+
+
+```r
+obj$task_status(t)
+#> 70db5d215affb4ba0c155c05d66803ce
+#>                           "DIED"
+obj$worker_status(w)
+#> capillary_irishterrier_1
+#>                   "LOST"
+```
+
+Fetching the task result provides the same DIED error as above:
+
+
+```r
+obj$task_result(t)
+#> <rrq_task_error>
+#>   error:  Task not successful: DIED
+#>   queue:  rrq:81b322b2
+#>   task:   70db5d215affb4ba0c155c05d66803ce
+#>   status: DIED
+#>   * To throw this error, use stop() with it
+```
+
+This is still not terribly useful, as we have not provided any mechanism to automatically requeue a lost task or restart a dead worker.

--- a/vignettes/rrq.Rmd
+++ b/vignettes/rrq.Rmd
@@ -33,7 +33,7 @@ id <- paste0("rrq:", ids::random_id(bytes = 4))
 obj <- rrq::rrq_controller$new(id)
 ```
 
-This controller uses an "identifier" (here, `id` is `rrq:f726361c`) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
+This controller uses an "identifier" (here, `id` is `rrq:3866bc2d`) which can be anything you want but acts like a folder within the Redis server, distinguishing your queue from any others hosted on the same server.
 
 Submit a task to the queue with the `$enqueue()` method, returning a key for that task
 
@@ -41,7 +41,7 @@ Submit a task to the queue with the `$enqueue()` method, returning a key for tha
 ```r
 t <- obj$enqueue(1 + 1)
 t
-#> [1] "5ee7f3e9eb51865caf36383b90ec98fb"
+#> [1] "985835bd5394edb00bb83e6db8c0186d"
 ```
 
 We'll also need some worker processes to carry out our tasks. Here, we'll spawn two for now (see the section below on alternatives to this)
@@ -49,8 +49,8 @@ We'll also need some worker processes to carry out our tasks. Here, we'll spawn 
 
 ```r
 rrq::rrq_worker_spawn(obj, 2)
-#> Spawning 2 workers with prefix tall_harpseal
-#> [1] "tall_harpseal_1" "tall_harpseal_2"
+#> Spawning 2 workers with prefix proportional_huia
+#> [1] "proportional_huia_1" "proportional_huia_2"
 ```
 
 Retrieve the result, polling if needed:
@@ -126,7 +126,7 @@ Initially the task has status `RUNNING` (it will be `PENDING` *very* briefly):
 
 ```r
 obj$task_status(t)
-#> f10831c514cb0ca8fb834d39ebd84aed
+#> 33b92e22260b09ff5f8a41b551c6452d
 #>                        "RUNNING"
 ```
 
@@ -136,7 +136,7 @@ Then after a couple of seconds it will complete (we pad this out here so that it
 ```r
 Sys.sleep(3)
 obj$task_result(t)
-#> [1] 0.8260605
+#> [1] 0.09538105
 ```
 
 The basic task lifecycle is this:
@@ -156,7 +156,7 @@ t <- obj$enqueue({
   runif(1)
 })
 obj$task_wait(t)
-#> [1] 0.7476675
+#> [1] 0.9406392
 ```
 
 The polling interval here is 1 second by default, but if the task completes within that period it will still be returned as soon as it is complete (the interval is just the time between progress bar updates and the period where an interrupt would be caught to cancel the wait).
@@ -166,9 +166,9 @@ Once a task is complete, `$task_wait` and `$task_result` are equivalent
 
 ```r
 obj$task_wait(t)
-#> [1] 0.7476675
+#> [1] 0.9406392
 obj$task_result(t)
-#> [1] 0.7476675
+#> [1] 0.9406392
 ```
 
 ## Configuring the worker environment
@@ -207,15 +207,15 @@ By default, this will notify all running workers to update their environment. No
 
 ```r
 obj$worker_log_tail(n = 4)
-#>         worker_id       time  command message
-#> 1 tall_harpseal_1 1678469096  MESSAGE REFRESH
-#> 2 tall_harpseal_2 1678469096  MESSAGE REFRESH
-#> 3 tall_harpseal_1 1678469096    ENVIR     new
-#> 4 tall_harpseal_2 1678469096    ENVIR     new
-#> 5 tall_harpseal_1 1678469096    ENVIR  create
-#> 6 tall_harpseal_2 1678469096    ENVIR  create
-#> 7 tall_harpseal_1 1678469096 RESPONSE REFRESH
-#> 8 tall_harpseal_2 1678469096 RESPONSE REFRESH
+#>             worker_id       time  command message
+#> 1 proportional_huia_1 1678974745  MESSAGE REFRESH
+#> 2 proportional_huia_2 1678974745  MESSAGE REFRESH
+#> 3 proportional_huia_1 1678974745    ENVIR     new
+#> 4 proportional_huia_2 1678974745    ENVIR     new
+#> 5 proportional_huia_1 1678974745    ENVIR  create
+#> 6 proportional_huia_2 1678974745    ENVIR  create
+#> 7 proportional_huia_1 1678974745 RESPONSE REFRESH
+#> 8 proportional_huia_2 1678974745 RESPONSE REFRESH
 ```
 
 Now our workers have picked up our functions we can start using them:
@@ -305,7 +305,7 @@ The status of the first task will be `PENDING`, per usual:
 
 ```r
 obj$task_status(id)
-#> c1cf05c6d3b7bae4410e01b4af6caee4
+#> b7f889625da2d63be4388a1926dd9cd0
 #>                        "PENDING"
 ```
 
@@ -314,14 +314,14 @@ however, the group of tasks submitted as part of the `$lapply` call will be `DEF
 
 ```r
 obj$task_status(id_use$task_ids)
-#> 43cbd3413fc0dc9d699f93e3a11f498b 515bc03172db3ed71f2e3575db806caa
+#> 50006660e699d84532dff1d366f6ee33 da8487b3ece5ec126ec0bbd5ceef89f4
 #>                       "DEFERRED"                       "DEFERRED"
-#> 1f4ba28cb390cc9f207d210843f3bb34 4010cab848a810e3a61fdb322e22436f
+#> 2d97304c47e6fb9a05cc03743be9b29c 738363324166739a90090f5215df8125
 #>                       "DEFERRED"                       "DEFERRED"
-#> baa1e590d3568f169239b0c920145737
+#> 298e2009c6084b03d62702c3707cd1ab
 #>                       "DEFERRED"
 obj$queue_list()
-#> [1] "c1cf05c6d3b7bae4410e01b4af6caee4"
+#> [1] "b7f889625da2d63be4388a1926dd9cd0"
 ```
 
 Once the first task is processed by a worker, the status changes:
@@ -331,19 +331,19 @@ Once the first task is processed by a worker, the status changes:
 
 ```r
 obj$task_status(id)
-#> c1cf05c6d3b7bae4410e01b4af6caee4
+#> b7f889625da2d63be4388a1926dd9cd0
 #>                       "COMPLETE"
 obj$task_status(id_use$task_ids)
-#> 43cbd3413fc0dc9d699f93e3a11f498b 515bc03172db3ed71f2e3575db806caa
+#> 50006660e699d84532dff1d366f6ee33 da8487b3ece5ec126ec0bbd5ceef89f4
 #>                        "PENDING"                        "PENDING"
-#> 1f4ba28cb390cc9f207d210843f3bb34 4010cab848a810e3a61fdb322e22436f
+#> 2d97304c47e6fb9a05cc03743be9b29c 738363324166739a90090f5215df8125
 #>                        "PENDING"                        "PENDING"
-#> baa1e590d3568f169239b0c920145737
+#> 298e2009c6084b03d62702c3707cd1ab
 #>                        "PENDING"
 obj$queue_list()
-#> [1] "baa1e590d3568f169239b0c920145737" "43cbd3413fc0dc9d699f93e3a11f498b"
-#> [3] "4010cab848a810e3a61fdb322e22436f" "515bc03172db3ed71f2e3575db806caa"
-#> [5] "1f4ba28cb390cc9f207d210843f3bb34"
+#> [1] "298e2009c6084b03d62702c3707cd1ab" "50006660e699d84532dff1d366f6ee33"
+#> [3] "da8487b3ece5ec126ec0bbd5ceef89f4" "2d97304c47e6fb9a05cc03743be9b29c"
+#> [5] "738363324166739a90090f5215df8125"
 ```
 
 At this point the tasks will proceed through the queue as usual.
@@ -371,7 +371,7 @@ obj <- rrq::rrq_controller$new(id)
 obj$worker_config_save("short", queue = "short")
 obj$worker_config_save("all", queue = c("short", "long"))
 obj$worker_config_list()
-#> [1] "short"     "all"       "localhost"
+#> [1] "localhost" "short"     "all"
 ```
 
 Above, we create two configurations: "short" which just listens on the queue `short`, and `all` which listens both on the short and long task queues (note that both these workers will also listen on the default queue).
@@ -379,11 +379,11 @@ Above, we create two configurations: "short" which just listens on the queue `sh
 
 ```r
 rrq::rrq_worker_spawn(obj, worker_config = "short")
-#> Spawning 1 worker with prefix equicontinuous_metamorphosis
-#> [1] "equicontinuous_metamorphosis_1"
+#> Spawning 1 worker with prefix insensible_cats
+#> [1] "insensible_cats_1"
 rrq::rrq_worker_spawn(obj, worker_config = "all")
-#> Spawning 1 worker with prefix stumpy_brahmancow
-#> [1] "stumpy_brahmancow_1"
+#> Spawning 1 worker with prefix peridot_addax
+#> [1] "peridot_addax_1"
 ```
 
 We can then submit a long task to the worker:
@@ -400,8 +400,8 @@ After the workers have had the ability to pick up work, our "short" worker is st
 
 ```r
 obj$worker_status()
-#> equicontinuous_metamorphosis_1            stumpy_brahmancow_1
-#>                         "IDLE"                         "BUSY"
+#> insensible_cats_1   peridot_addax_1
+#>            "IDLE"            "BUSY"
 ```
 
 So we can submit tasks to this short queue and have them processed
@@ -410,7 +410,7 @@ So we can submit tasks to this short queue and have them processed
 ```r
 id <- obj$enqueue(runif(1), queue = "short")
 obj$task_wait(id, timeout = 10)
-#> [1] 0.7349525
+#> [1] 0.3042377
 ```
 
 Note that there is no validation to check that any worker is listening on any queue when you submit a task. Indeed there can't be as new workers can be added at any time (so at the point of submission perhaps there were no workers).
@@ -456,8 +456,8 @@ then we create the queue object as normal (and spawn a worker so that we can use
 ```r
 obj <- rrq::rrq_controller$new(id)
 rrq::rrq_worker_spawn(obj, 1)
-#> Spawning 1 worker with prefix autecological_aldabratortoise
-#> [1] "autecological_aldabratortoise_1"
+#> Spawning 1 worker with prefix gnomological_germanwirehairedpointer
+#> [1] "gnomological_germanwirehairedpointer_1"
 ```
 
 It's not hard at all to get to 1KB of data, we can do that by simulating a big pile of random numbers:
@@ -474,7 +474,7 @@ Once the task has finished, data will be stored on disk below the path given abo
 
 ```r
 dir(path)
-#> [1] "edfca7ad36028fd108fea91223c7761d"
+#> [1] "a8b0646d93a785197435cdc0c21ff150"
 ```
 
 
@@ -555,37 +555,37 @@ Then, launch a worker
 
 ```r
 rrq::rrq_worker_spawn(obj, 1)
-#> Spawning 1 worker with prefix elephantiasic_chamois
-#> [1] "elephantiasic_chamois_1"
+#> Spawning 1 worker with prefix careful_bighorn
+#> [1] "careful_bighorn_1"
 ```
 
 Our worker will print information indicating that the heartbeat is enabled (use `obj$worker_process_log()`)
 
 
 ```
-#> [2023-03-10 17:25:00] QUEUE default
-#> [2023-03-10 17:25:00] ENVIR new
-#> [2023-03-10 17:25:00] HEARTBEAT rrq:2788c539:worker:elephantiasic_chamois_1:heartbeat
-#> [2023-03-10 17:25:00] HEARTBEAT OK
-#> [2023-03-10 17:25:00] ALIVE
+#> [2023-03-16 13:52:30] QUEUE default
+#> [2023-03-16 13:52:30] ENVIR new
+#> [2023-03-16 13:52:30] HEARTBEAT rrq:ba149f14:worker:careful_bighorn_1:heartbeat
+#> [2023-03-16 13:52:30] HEARTBEAT OK
+#> [2023-03-16 13:52:30] ALIVE
 #>                                  __
 #>                 ______________ _/ /
 #>       ______   / ___/ ___/ __ `/ /_____
 #>      /_____/  / /  / /  / /_/ /_/_____/
 #>  ______      /_/  /_/   \__, (_)   ______
 #> /_____/                   /_/     /_____/
-#>     worker:        elephantiasic_chamois_1
-#>     rrq_version:   0.6.12
+#>     worker:        careful_bighorn_1
+#>     rrq_version:   0.6.14
 #>     platform:      x86_64-pc-linux-gnu (64-bit)
 #>     running:       Ubuntu 20.04.5 LTS
-#>     hostname:      wpia-dide300
-#>     username:      rfitzjoh
-#>     queue:         rrq:2788c539:queue:default
-#>     wd:            /home/rfitzjoh/Documents/src/rrq/vignettes_src
-#>     pid:           908661
+#>     hostname:      wpia-dide136
+#>     username:      rich
+#>     queue:         rrq:ba149f14:queue:default
+#>     wd:            /home/rich/tmp/rrq/vignettes_src
+#>     pid:           54621
 #>     redis_host:    127.0.0.1
 #>     redis_port:    6379
-#>     heartbeat_key: rrq:2788c539:worker:elephantiasic_chamois_1:heartbeat
+#>     heartbeat_key: rrq:ba149f14:worker:careful_bighorn_1:heartbeat
 ```
 
 We also have a heartbeat key here that we can inspect:
@@ -596,7 +596,7 @@ info <- obj$worker_info()[[1]]
 obj$con$EXISTS(info$heartbeat_key)
 #> [1] 1
 obj$con$PTTL(info$heartbeat_key) # in milliseconds
-#> [1] 5955
+#> [1] 5948
 ```
 
 We queue some slow job onto the worker:
@@ -640,7 +640,7 @@ So far as `rrq` is concerned, at this point your task is still running
 
 ```r
 obj$task_status(t)
-#> d6ec0735555aa0991505f4bc7c656fa7
+#> d09de81c70f7f77491b7df1c135de211
 #>                        "RUNNING"
 ```
 
@@ -650,9 +650,9 @@ Handling this situation is still completely manual.  You can detect lost workers
 ```r
 obj$worker_detect_exited()
 #> Lost 1 worker:
-#>   - elephantiasic_chamois_1
+#>   - careful_bighorn_1
 #> Orphaning 1 task:
-#>   - d6ec0735555aa0991505f4bc7c656fa7
+#>   - d09de81c70f7f77491b7df1c135de211
 ```
 
 this will also "orphan" the task
@@ -660,7 +660,7 @@ this will also "orphan" the task
 
 ```r
 obj$task_status(t)
-#> d6ec0735555aa0991505f4bc7c656fa7
+#> d09de81c70f7f77491b7df1c135de211
 #>                           "DIED"
 ```
 

--- a/vignettes_src/fault-tolerance.Rmd
+++ b/vignettes_src/fault-tolerance.Rmd
@@ -23,7 +23,7 @@ In a perfect world, nothing would fail, and this vignette would not be needed. B
 
 When you run tasks within a single process and things go wrong, you know immediately you see it happen. With a queuing system like rrq it's less obvious when something bad has happened because the task is running on another process, possibly on a different machine!
 
-* Plain errors (handled briefly below) is the simplest sort of fault to recover from. Your task throws an error, `rrq` picks this up and marks the task as errored, and moves on to the next thing. You can then see that this error has happened as its status.
+* Plain errors are the simplest sort of fault to recover from. Your task throws an error, `rrq` picks this up and marks the task as errored, and moves on to the next thing. You can then see that this error has happened as its status.
 * If your task crashes the process it can take out the worker (depending on how you have configured rrq; see below). In this case nothing updates the task status, and your task appears to stay running forever. This situation also arises if your process is killed by the operating system (e.g., out of memory) or via some other condition (e.g., an administrator terminating the process).
 * If your task is running on another machine and that machine becomes unreachable (switched off, disconnects from the network, etc) your task will never appear to finish.
 
@@ -36,13 +36,12 @@ We start with the simplest sort of fault, and can just as easily happen locally 
 Consider this simple function which would fit a linear model between two variables:
 
 ```{r results = "asis", echo = FALSE}
-lang_output("r", "fault.R")
+lang_output(readLines("fault.R"), "r")
 ```
 
 ```{r}
 obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
 obj$envir(rrq::rrq_envir(sources = "fault.R"))
-source("fault.R")
 rrq::rrq_worker_spawn(obj)
 ```
 
@@ -73,7 +72,7 @@ r
 However, the result will be an object of `rrq_task_error` which you can test for using `inherits`:
 
 ```{r}
-inherits(r, "task_error")
+inherits(r, "rrq_task_error")
 ```
 
 The default behaviour of `rrq` is not to error when fetching a task as that would require that you use `tryCatch` everywhere where you retrieve tasks that might have failed, and because errors are often interesting themselves. For example, `rrq_task_error` objects include stack traces alongside the error:
@@ -82,7 +81,7 @@ The default behaviour of `rrq` is not to error when fetching a task as that woul
 r$trace
 ```
 
-These are `rlang` stack traces, which are somewhat richer than those produced by `traceback()`, containing the same set of stacks but arranged in a tree. See the documentation there for details. The errors also include any warnings captured while the task ran.
+These are `rlang` stack traces, which are somewhat richer than those produced by `traceback()`, containing the same set of stacks but arranged in a tree. See the [documentation there](https://rlang.r-lib.org/reference/trace_back.html) for details. This error object will also include any warnings captured while the task ran.
 
 Objects of class `rrq_task_error` inherit from `error` and `condition` so, once thrown, will behave as expected in programs using errors for flow control (e.g., with `tryCatch`); you can throw them yourself with  `stop()`:
 
@@ -90,15 +89,13 @@ Objects of class `rrq_task_error` inherit from `error` and `condition` so, once 
 stop(r)
 ```
 
-You can also change the default behaviour to error on failure by passing  `error = TRUE` to any of `$task_result()`, `$task_wait()`, `$tasks_result()` or `$tasks_wait()`:
+You can also change the default behaviour to error on failure by passing  `error = TRUE` to any of `$task_result()`, `$task_wait()`, `$tasks_result()` or `$tasks_wait()`, which will immediately rethrow the error in your R session (your program could then stop or you could again catch it with `tryCatch`):
 
 ```{r, error = TRUE}
 obj$task_result(t, error = TRUE)
 ```
 
 This process is unchanged if the task is run in a separate process (with `separate_process = TRUE` passed to `enqueue`), with the same status and return type, and with the trace information available after failure.
-
-(TODO - check this)
 
 ## Increasing resiliance via separate processes
 
@@ -127,40 +124,32 @@ t <- obj$enqueue(Sys.sleep(3600), separate_process = TRUE)
 ```
 
 ```{r, include = FALSE}
-pid <- function() {
-  for (i in 1:10) {
-    log <- obj$worker_log_tail(n = 1)
-    if (log$command == "REMOTE_PID") {
-      return(as.integer(log$message))
-    }
-    Sys.sleep(0.2)
-  }
-  stop("Failure to get pid from worker")
-}()
+rrq:::wait_status_change(obj$con, rrq:::rrq_keys(obj$queue_id), t, rrq:::TASK_PENDING)
 ```
 
-To simulate the process crashing, we've killed it:
+To simulate the process crashing, we've killed it. Because we have queued this on a separate process we can use `$task_info()` to fetch the process id (PID) of the process that the task is running in (this is different to that of the worker).
 
 ```{r}
-tools::pskill(pid)
+info <- obj$task_info(t)
+tools::pskill(info$pid)
 ```
 
-```{r, include = TRUE}
-## We need to wait here for a minute because the kill won't be instant
+```{r, include = FALSE, error = TRUE}
+## We need to wait here for a few seconds because the kill won't be instant
 obj$task_wait(t, 10)
 ```
 
 Because the task was run in a separate process, our worker could detect that the task has died unexpectedly:
 
-```
+```{r}
 obj$task_status(t)
 ```
 
-This is different to the error status above (that was `r rrq:::TASK_ERROR`). Note that if we had not run the task in a separate process the task status would be unchanged as `r rrq:::TASK_RUNNING`) because nothing could ever update the task status!
+This is different to the error status in the previous section (that was `r rrq:::TASK_ERROR`). Note that if we had not run the task in a separate process the task status would be unchanged as `r rrq:::TASK_RUNNING`) because nothing could ever update the task status!
 
 Retrieving the result has similar behaviour to the error case; we don't throw but instead return an object of class `rrq_task_error` (which also inherits from `error` and `condition`). However, this time there's really not much extra information in the error:
 
-```
+```{r}
 r <- obj$task_result(t)
 r
 ```
@@ -178,13 +167,14 @@ In this section we outline what you can do about unexplained and unreported fail
 In order to enable fault tolerance for this sort of issue, you first need to enable a "heatbeat" on the worker processes. This is a second process on each worker that periodically writes to the Redis database on a key that will expire in a time slightly longer than that period, in effect making a [dead man's switch](https://en.wikipedia.org/wiki/Dead_man%27s_switch) - see `rrq::rrq_heartbeat` for details. So if the worker process dies for any reason, then after a while we'll detect that as its key has expired. We can then take some action.
 
 ```{r, include = FALSE}
-obj$worker_stop()
+obj$worker_stop(timeout = 10)
+obj$worker_delete_exited()
 ```
 
 To enable the heartbeat, save a worker configuration before starting a worker:
 
 ```{r}
-obj$worker_config_save("localhost", heartbeat_period = 3)
+obj$worker_config_save("localhost", heartbeat_period = 3, overwrite = TRUE)
 ```
 
 When you spawn a worker it will pick up this configuration, and we'll be able to detect if it has died.
@@ -207,7 +197,7 @@ t <- obj$enqueue(Sys.sleep(3600))
 ```
 
 ```{r, include = FALSE}
-Sys.sleep(1)
+rrq:::wait_status_change(obj$con, rrq:::rrq_keys(obj$queue_id), t, rrq:::TASK_PENDING)
 ```
 
 The worker wil pick the task up fairly quickly, and the status will change to `RUNNING`:
@@ -217,7 +207,7 @@ obj$task_status(t)
 obj$worker_status(w)
 ```
 
-We kill the worker:
+We kill the worker (simulating the job crashing, or the machine turning off, etc):
 
 ```{r}
 tools::pskill(w_pid)

--- a/vignettes_src/fault-tolerance.Rmd
+++ b/vignettes_src/fault-tolerance.Rmd
@@ -227,7 +227,7 @@ obj$task_status(t)
 obj$worker_status(w)
 ```
 
-However, if we wait until after the heartbeat key will have expired (9s = 3 * 3s, the time we saved above)
+The heartbeat will persist for 3 times the period given above (this multiplier is not configurable and while any number greater than 1 should be OK, we picked this as it allows for occasional network connectivity issues or slowness on the node - we may reduce it in a future version). This means that after 9s (3 * 3s) the key will have expired:
 
 ```{r wait_for_expiry}
 Sys.sleep(10)

--- a/vignettes_src/fault-tolerance.Rmd
+++ b/vignettes_src/fault-tolerance.Rmd
@@ -27,7 +27,7 @@ When you run tasks within a single process and things go wrong, you know immedia
 * If your task crashes the process it can take out the worker (depending on how you have configured rrq; see below). In this case nothing updates the task status, and your task appears to stay running forever. This situation also arises if your process is killed by the operating system (e.g., out of memory) or via some other condition (e.g., an administrator terminating the process).
 * If your task is running on another machine and that machine becomes unreachable (switched off, disconnects from the network, etc) your task will never appear to finish.
 
-This vignette discusses how you can mitigate against and recover from these sorts of issues.
+This vignette discusses how you can mitigate against and recover from these sorts of issues. We start with the expected errors and build up to considerations for creating a fault tolerant queue.
 
 ## Error handling
 
@@ -38,7 +38,6 @@ Consider this simple function which would fit a linear model between two variabl
 ```{r results = "asis", echo = FALSE}
 lang_output("r", "fault.R")
 ```
-
 
 ```{r}
 obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
@@ -67,35 +66,43 @@ obj$task_wait(t, 10)
 The first thing to note here is that the task does not throw an error when you fetch the result, either via `task_wait` as above, or via `task_result`:
 
 ```{r}
-obj$task_result(t)
+r <- obj$task_result(t)
+r
 ```
 
 However, the result will be an object of `rrq_task_error` which you can test for using `inherits`:
 
 ```{r}
-r <- obj$task_result(r)
 inherits(r, "task_error")
 ```
 
-(this object also inherits from `error` and `condition` so behaves as expected, if you are used to handling errors directly). If you want this error to propagate upwards you can simply throw it yourself:
-
-```{r, error = TRUE}
-stop(r)
-```
-
-However, `rrq` does not throw it for you because otherwise interacting with task results would require you to use `tryCatch` or similar everywhere there is a chance of an error, and because the errors are usually interesting.
-
-Included in the error is the full stack trace from the worker process (here wrapped in `writeLines` so that prints nicely)
+The default behaviour of `rrq` is not to error when fetching a task as that would require that you use `tryCatch` everywhere where you retrieve tasks that might have failed, and because errors are often interesting themselves. For example, `rrq_task_error` objects include stack traces alongside the error:
 
 ```{r}
 r$trace
 ```
 
+These are `rlang` stack traces, which are somewhat richer than those produced by `traceback()`, containing the same set of stacks but arranged in a tree. See the documentation there for details. The errors also include any warnings captured while the task ran.
+
+Objects of class `rrq_task_error` inherit from `error` and `condition` so, once thrown, will behave as expected in programs using errors for flow control (e.g., with `tryCatch`); you can throw them yourself with  `stop()`:
+
+```{r, error = TRUE}
+stop(r)
+```
+
+You can also change the default behaviour to error on failure by passing  `error = TRUE` to any of `$task_result()`, `$task_wait()`, `$tasks_result()` or `$tasks_wait()`:
+
+```{r, error = TRUE}
+obj$task_result(t, error = TRUE)
+```
+
 This process is unchanged if the task is run in a separate process (with `separate_process = TRUE` passed to `enqueue`), with the same status and return type, and with the trace information available after failure.
 
-## Recovery via separate processes
+(TODO - check this)
 
-Running tasks in separate processes (e.g., `obj$enqueue(mytask(), separate_process = TRUE)`) is the simplest way of making things more fault tolerant because this creates a layer of isolation between the worker and the task. If your task crashes R (e.g., a segmentation fault due to a bug in your C/C++ code) or is killed by the operating system then the worker process survives and can update the keys in Redis directly.
+## Increasing resiliance via separate processes
+
+Running tasks in separate processes (e.g., `obj$enqueue(mytask(), separate_process = TRUE)`) is the simplest way of making things more resiliant because this creates a layer of isolation between the worker and the task. If your task crashes R (e.g., a segmentation fault due to a bug in your C/C++ code) or is killed by the operating system then the worker process survives and can update the keys in Redis directly to advertise this fact. This is geerally much nicer than when the worker dies and the task status cannot be updated.
 
 The downside of using separate processes is that it is much slower; compare the time taken to queue, run an retrieve a trivial task run in the same worker process (look at the `elapsed` entry)
 
@@ -149,7 +156,7 @@ Because the task was run in a separate process, our worker could detect that the
 obj$task_status(t)
 ```
 
-This is different to the error status above (that was `r rrq:::TASK_ERROR`).
+This is different to the error status above (that was `r rrq:::TASK_ERROR`). Note that if we had not run the task in a separate process the task status would be unchanged as `r rrq:::TASK_RUNNING`) because nothing could ever update the task status!
 
 Retrieving the result has similar behaviour to the error case; we don't throw but instead return an object of class `rrq_task_error` (which also inherits from `error` and `condition`). However, this time there's really not much extra information in the error:
 

--- a/vignettes_src/fault-tolerance.Rmd
+++ b/vignettes_src/fault-tolerance.Rmd
@@ -1,0 +1,249 @@
+---
+title: "Fault tolerance"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Fault tolerance}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  error = FALSE,
+  collapse = TRUE,
+  comment = "#>"
+)
+
+lang_output <- function(x, lang) {
+  cat(c(sprintf("```%s", lang), x, "```"), sep = "\n")
+}
+```
+
+In a perfect world, nothing would fail, and this vignette would not be needed. But here we are.
+
+When you run tasks within a single process and things go wrong, you know immediately you see it happen. With a queuing system like rrq it's less obvious when something bad has happened because the task is running on another process, possibly on a different machine!
+
+* Plain errors (handled briefly below) is the simplest sort of fault to recover from. Your task throws an error, `rrq` picks this up and marks the task as errored, and moves on to the next thing. You can then see that this error has happened as its status.
+* If your task crashes the process it can take out the worker (depending on how you have configured rrq; see below). In this case nothing updates the task status, and your task appears to stay running forever. This situation also arises if your process is killed by the operating system (e.g., out of memory) or via some other condition (e.g., an administrator terminating the process).
+* If your task is running on another machine and that machine becomes unreachable (switched off, disconnects from the network, etc) your task will never appear to finish.
+
+This vignette discusses how you can mitigate against and recover from these sorts of issues.
+
+## Error handling
+
+We start with the simplest sort of fault, and can just as easily happen locally as remotely with `rrq`. In this case the handling is fairly well defined and there's not much you need to do. This section is not really "fault tolerance" at all, but simply how rrq handles errors and what you can do about it.
+
+Consider this simple function which would fit a linear model between two variables:
+
+```{r results = "asis", echo = FALSE}
+lang_output("r", "fault.R")
+```
+
+
+```{r}
+obj <- rrq::rrq_controller$new(paste0("rrq:", ids::random_id(bytes = 4)))
+obj$envir(rrq::rrq_envir(sources = "fault.R"))
+source("fault.R")
+rrq::rrq_worker_spawn(obj)
+```
+
+In the happy case, everything works as expected:
+
+```{r}
+x <- runif(5)
+y <- 2 * x + rnorm(length(x), 0, 0.2)
+t <- obj$enqueue(fit_model(x, y))
+obj$task_wait(t, 10)
+obj$task_status(t)
+```
+
+But if we provide invalid input, the task will error:
+
+```{r}
+t <- obj$enqueue(fit_model(x, NULL))
+obj$task_wait(t, 10)
+```
+
+The first thing to note here is that the task does not throw an error when you fetch the result, either via `task_wait` as above, or via `task_result`:
+
+```{r}
+obj$task_result(t)
+```
+
+However, the result will be an object of `rrq_task_error` which you can test for using `inherits`:
+
+```{r}
+r <- obj$task_result(r)
+inherits(r, "task_error")
+```
+
+(this object also inherits from `error` and `condition` so behaves as expected, if you are used to handling errors directly). If you want this error to propagate upwards you can simply throw it yourself:
+
+```{r, error = TRUE}
+stop(r)
+```
+
+However, `rrq` does not throw it for you because otherwise interacting with task results would require you to use `tryCatch` or similar everywhere there is a chance of an error, and because the errors are usually interesting.
+
+Included in the error is the full stack trace from the worker process (here wrapped in `writeLines` so that prints nicely)
+
+```{r}
+r$trace
+```
+
+This process is unchanged if the task is run in a separate process (with `separate_process = TRUE` passed to `enqueue`), with the same status and return type, and with the trace information available after failure.
+
+## Recovery via separate processes
+
+Running tasks in separate processes (e.g., `obj$enqueue(mytask(), separate_process = TRUE)`) is the simplest way of making things more fault tolerant because this creates a layer of isolation between the worker and the task. If your task crashes R (e.g., a segmentation fault due to a bug in your C/C++ code) or is killed by the operating system then the worker process survives and can update the keys in Redis directly.
+
+The downside of using separate processes is that it is much slower; compare the time taken to queue, run an retrieve a trivial task run in the same worker process (look at the `elapsed` entry)
+
+```{r}
+system.time(
+  obj$task_wait(obj$enqueue(identity(1)), 10))
+```
+
+with the same task run in a separate process on the worker
+
+```{r}
+system.time(
+  obj$task_wait(obj$enqueue(identity(1), separate_process = TRUE), 10))
+```
+
+We expect this difference to be ~100 fold in local workers. Almost all the cost is due to the overhead of starting and terminating a fresh R session. If your queue uses a lot of packages there will be additional overhead here too as these are loaded. However, this cost is fixed and will decrease as a fraction of the total running time as the running time of your task increases. So for long-running tasks the additional safety of separate processes is probably worthwhile. For smaller tasks you may want to make sure you run a heartbeat process so that you can handle failures via that route.
+
+Consider running some long running job; this one simply sleeps for an hour
+
+```{r}
+t <- obj$enqueue(Sys.sleep(3600), separate_process = TRUE)
+```
+
+```{r, include = FALSE}
+pid <- function() {
+  for (i in 1:10) {
+    log <- obj$worker_log_tail(n = 1)
+    if (log$command == "REMOTE_PID") {
+      return(as.integer(log$message))
+    }
+    Sys.sleep(0.2)
+  }
+  stop("Failure to get pid from worker")
+}()
+```
+
+To simulate the process crashing, we've killed it:
+
+```{r}
+tools::pskill(pid)
+```
+
+```{r, include = TRUE}
+## We need to wait here for a minute because the kill won't be instant
+obj$task_wait(t, 10)
+```
+
+Because the task was run in a separate process, our worker could detect that the task has died unexpectedly:
+
+```
+obj$task_status(t)
+```
+
+This is different to the error status above (that was `r rrq:::TASK_ERROR`).
+
+Retrieving the result has similar behaviour to the error case; we don't throw but instead return an object of class `rrq_task_error` (which also inherits from `error` and `condition`). However, this time there's really not much extra information in the error:
+
+```
+r <- obj$task_result(t)
+r
+```
+
+There's also no trace available
+
+```{r}
+r$trace
+```
+
+## Loss of workers
+
+In this section we outline what you can do about unexplained and unreported failures in your task, or loss of workers. This will typically be that your worker has crashed (due to your task crashing it perhaps), killed (e.g., by the operating system or an administrator) or the loss of the machine that it is working on.
+
+In order to enable fault tolerance for this sort of issue, you first need to enable a "heatbeat" on the worker processes. This is a second process on each worker that periodically writes to the Redis database on a key that will expire in a time slightly longer than that period, in effect making a [dead man's switch](https://en.wikipedia.org/wiki/Dead_man%27s_switch) - see `rrq::rrq_heartbeat` for details. So if the worker process dies for any reason, then after a while we'll detect that as its key has expired. We can then take some action.
+
+```{r, include = FALSE}
+obj$worker_stop()
+```
+
+To enable the heartbeat, save a worker configuration before starting a worker:
+
+```{r}
+obj$worker_config_save("localhost", heartbeat_period = 3)
+```
+
+When you spawn a worker it will pick up this configuration, and we'll be able to detect if it has died.
+
+```{r}
+w <- rrq::rrq_worker_spawn(obj)
+```
+
+In order to simulate the loss of the worker, we need its [process id (PID)](https://en.wikipedia.org/wiki/Process_identifier), which we can get from the controller object:
+
+```{r}
+w_pid <- obj$worker_info()[[w]]$pid
+w_pid
+```
+
+Now, we can queue some long running process, which this worker will start:
+
+```{r}
+t <- obj$enqueue(Sys.sleep(3600))
+```
+
+```{r, include = FALSE}
+Sys.sleep(1)
+```
+
+The worker wil pick the task up fairly quickly, and the status will change to `RUNNING`:
+
+```{r}
+obj$task_status(t)
+obj$worker_status(w)
+```
+
+We kill the worker:
+
+```{r}
+tools::pskill(w_pid)
+```
+
+Because the worker has been killed, it can't write to redis to tell us that the task can't be completed, so this status will never change:
+
+```{r}
+obj$task_status(t)
+obj$worker_status(w)
+```
+
+However, if we wait until after the heartbeat key will have expired (9s = 3 * 3s, the time we saved above)
+
+```{r}
+Sys.sleep(10)
+```
+
+We can then use the `worker_detect_exited()` method to clean up
+
+```{r}
+obj$worker_detect_exited()
+```
+
+At this point, the statuses of our task and worker are correct:
+
+```{r}
+obj$task_status(t)
+obj$worker_status(w)
+```
+
+This is still not terribly useful, as we have not provided any mechanism to automatically requeue a lost task or restart a dead worker.
+
+```{r}
+obj$task_result(t)
+```

--- a/vignettes_src/fault-tolerance.Rmd
+++ b/vignettes_src/fault-tolerance.Rmd
@@ -124,7 +124,11 @@ t <- obj$enqueue(Sys.sleep(3600), separate_process = TRUE)
 ```
 
 ```{r, include = FALSE}
+# small sleep here needed so that the pid is actually available;
+# two small conditions to pass.
 rrq:::wait_status_change(obj$con, rrq:::rrq_keys(obj$queue_id), t, rrq:::TASK_PENDING)
+rrq:::wait_timeout("pid not available in time", 10,
+                   function() is.null(obj$task_info(t)$pid))
 ```
 
 To simulate the process crashing, we've killed it. Because we have queued this on a separate process we can use `$task_info()` to fetch the process id (PID) of the process that the task is running in (this is different to that of the worker).
@@ -134,9 +138,8 @@ info <- obj$task_info(t)
 tools::pskill(info$pid)
 ```
 
-```{r, include = FALSE, error = TRUE}
-## We need to wait here for a few seconds because the kill won't be instant
-obj$task_wait(t, 10)
+```{r, include = FALSE}
+rrq:::wait_status_change(obj$con, rrq:::rrq_keys(obj$queue_id), t, rrq:::TASK_RUNNING)
 ```
 
 Because the task was run in a separate process, our worker could detect that the task has died unexpectedly:
@@ -166,7 +169,7 @@ In this section we outline what you can do about unexplained and unreported fail
 
 In order to enable fault tolerance for this sort of issue, you first need to enable a "heatbeat" on the worker processes. This is a second process on each worker that periodically writes to the Redis database on a key that will expire in a time slightly longer than that period, in effect making a [dead man's switch](https://en.wikipedia.org/wiki/Dead_man%27s_switch) - see `rrq::rrq_heartbeat` for details. So if the worker process dies for any reason, then after a while we'll detect that as its key has expired. We can then take some action.
 
-```{r, include = FALSE}
+```{r stop-workers, include = FALSE}
 obj$worker_stop(timeout = 10)
 obj$worker_delete_exited()
 ```
@@ -207,6 +210,10 @@ obj$task_status(t)
 obj$worker_status(w)
 ```
 
+<!-- ```{r} -->
+<!-- Sys.sleep(1) -->
+<!-- ``` -->
+
 We kill the worker (simulating the job crashing, or the machine turning off, etc):
 
 ```{r}
@@ -222,7 +229,7 @@ obj$worker_status(w)
 
 However, if we wait until after the heartbeat key will have expired (9s = 3 * 3s, the time we saved above)
 
-```{r}
+```{r wait_for_expiry}
 Sys.sleep(10)
 ```
 
@@ -239,8 +246,10 @@ obj$task_status(t)
 obj$worker_status(w)
 ```
 
-This is still not terribly useful, as we have not provided any mechanism to automatically requeue a lost task or restart a dead worker.
+Fetching the task result provides the same `r rrq:::TASK_DIED` error as above:
 
 ```{r}
 obj$task_result(t)
 ```
+
+This is still not terribly useful, as we have not provided any mechanism to automatically requeue a lost task or restart a dead worker.

--- a/vignettes_src/fault.R
+++ b/vignettes_src/fault.R
@@ -1,0 +1,3 @@
+fit_model <- function(x, y) {
+  lm(y ~ x)
+}


### PR DESCRIPTION
This will get expanded once we get support for retrying tasks, but provides the context for that.

I've also fixed a weird bug that I thought we had an issue for (but can't find) where task_result on jobs that were lost via worker death and separate process death were not the same - now we always return an rrq_task_error