### PR TITLE
Prevent accumulation of junk worker logs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.15
+Version: 0.6.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/heartbeat.R
+++ b/R/heartbeat.R
@@ -1,10 +1,11 @@
 worker_heartbeat <- function(con, keys, period, verbose) {
   if (!is.null(period)) {
+    is_child <- FALSE
     key <- keys$worker_heartbeat
-    worker_log(con, keys, "HEARTBEAT", key, verbose)
+    worker_log(con, keys, "HEARTBEAT", key, is_child, verbose)
     config <- con$config()
     ret <- rrq_heartbeat$new(key, period, config = config)
-    worker_log(con, keys, "HEARTBEAT", "OK", verbose)
+    worker_log(con, keys, "HEARTBEAT", "OK", is_child, verbose)
     ret
   }
 }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -965,7 +965,9 @@ rrq_controller <- R6::R6Class(
 
     ##' @description Returns the last (few) elements in the worker
     ##' log. The log will be returned as a [data.frame] of entries
-    ##' `worker_id` (the worker id), `time` (the time in Redis when the
+    ##' `worker_id` (the worker id), `child` (the process id, an integer,
+    ##' where logs come from a child process from a task queued with
+    ##' `separate_process = TRUE`), `time` (the time in Redis when the
     ##' event happened; see [redux::redis_time] to convert this to an R
     ##' time), `command` (the worker command) and `message` (the message
     ##' corresponding to that command).

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1577,6 +1577,7 @@ worker_log_tail <- function(con, keys, worker_ids = NULL, n = 1) {
     ret
   } else {
     data_frame(worker_id = character(0),
+               child = integer(0),
                time = numeric(0),
                command = character(0),
                message = character(0))
@@ -1595,14 +1596,15 @@ worker_log_tail_1 <- function(con, keys, worker_id, n = 1) {
 
 
 worker_log_parse <- function(log, worker_id) {
-  re <- "^([0-9.]+) ([^ ]+) ?(.*)$"
+  re <- "^([0-9.]+)(/[0-9]+)? ([^ ]+) ?(.*)$"
   if (!all(grepl(re, log))) {
     stop("Corrupt log")
   }
   time <- as.numeric(sub(re, "\\1", log))
-  command <- sub(re, "\\2", log)
-  message <- lstrip(sub(re, "\\3", log))
-  data.frame(worker_id, time, command, message, stringsAsFactors = FALSE)
+  child <- as.integer(sub("/", "", sub(re, "\\2", log)))
+  command <- sub(re, "\\3", log)
+  message <- lstrip(sub(re, "\\4", log))
+  data_frame(worker_id, child, time, command, message)
 }
 
 

--- a/R/worker.R
+++ b/R/worker.R
@@ -102,12 +102,6 @@ rrq_worker <- R6::R6Class(
     ##' @param queue Queues to listen on, listed in decreasing order of
     ##'   priority. If not given, we listen on the "default" queue.
     ##'
-    ##' @param register Logical, indicating if the worker should be
-    ##'   registered with the controller. Typically this is `TRUE`, but
-    ##'   set to `FALSE` if you need to impersonate a worker, or create a
-    ##'   temporary worker. This is passed as `FALSE` when running a task
-    ##'   in a separate process.
-    ##'
     ##' @param timeout_poll Optional timeout indicating how long to wait
     ##'   for a background process to produce stdout or stderr. Only used
     ##'   for tasks queued with `separate_process` `TRUE`.
@@ -116,11 +110,16 @@ rrq_worker <- R6::R6Class(
     ##'   wait for the background process to respond to SIGTERM before
     ##'   we stop the worker. Only used for tasks queued with
     ##'   `separate_process` `TRUE`.
+    ##'
+    ##' @param is_child Logical, used to indicate that this is a child of
+    ##'   the real worker.  If `is_child` is `TRUE`, then most other
+    ##'   arguments here have no effect (e.g., `queue` all the timeout /
+    ##'   idle / polling arguments) as they come from the parent.
     initialize = function(queue_id, con = redux::hiredis(),
                           key_alive = NULL, worker_name = NULL,
                           queue = NULL, time_poll = NULL, timeout_idle = NULL,
                           heartbeat_period = NULL, verbose = TRUE,
-                          register = TRUE, timeout_poll = 1, timeout_die = 2) {
+                          is_child = FALSE, timeout_poll = 1, timeout_die = 2) {
       assert_is(con, "redis_api")
 
       private$con <- con
@@ -128,15 +127,17 @@ rrq_worker <- R6::R6Class(
       lockBinding("name", self)
       private$keys <- rrq_keys(queue_id, self$name)
       private$verbose <- verbose
+      private$is_child <- is_child
 
       rrq_version_check(private$con, private$keys)
 
-      queue <- worker_queue(queue)
-      private$queue <- rrq_key_queue(queue_id, queue)
-      self$log("QUEUE", queue)
-
-      if (private$con$SISMEMBER(private$keys$worker_name, self$name) == 1L) {
-        stop("Looks like this worker exists already...")
+      worker_exists <- con$SISMEMBER(private$keys$worker_name, self$name) == 1L
+      if (is_child != worker_exists) {
+        if (is_child) {
+          stop("Can't be a child of nonexistant worker...")
+        } else {
+          stop("Looks like this worker exists already...")
+        }
       }
 
       private$store <- rrq_object_store(private$con, private$keys)
@@ -144,13 +145,16 @@ rrq_worker <- R6::R6Class(
       private$timeout_poll <- timeout_poll
       private$timeout_die <- timeout_die
 
-      self$load_envir()
-      if (register) {
+      if (private$is_child) {
+        self$log("CHILD")
+      } else {
         withCallingHandlers(
-          worker_initialise(self, private,
+          worker_initialise(self, private, worker_queue(queue),
                             key_alive, timeout_idle, heartbeat_period),
           error = worker_catch_error(self, private))
       }
+
+      self$load_envir()
     },
 
     ##' @description Return information about this worker, a list of
@@ -166,7 +170,8 @@ rrq_worker <- R6::R6Class(
     ##'
     ##' @param value Character vector (or null) with log values
     log = function(label, value = NULL) {
-      worker_log(private$con, private$keys, label, value, private$verbose)
+      worker_log(private$con, private$keys, label, value, private$is_child,
+                 private$verbose)
     },
 
     ##' @description Load the worker environment by creating a new
@@ -312,6 +317,7 @@ rrq_worker <- R6::R6Class(
     store = NULL,
     time_poll = NULL,
     verbose = NULL,
+    is_child = NULL,
     timeout_poll = NULL,
     timeout_die = NULL
   ))
@@ -338,7 +344,7 @@ worker_info_collect <- function(worker, private) {
 }
 
 
-worker_initialise <- function(worker, private, key_alive, timeout_idle,
+worker_initialise <- function(worker, private, queue, key_alive, timeout_idle,
                               heartbeat_period) {
   con <- private$con
   keys <- private$keys
@@ -357,7 +363,10 @@ worker_initialise <- function(worker, private, key_alive, timeout_idle,
     run_message_timeout_set(worker, private, timeout_idle)
   }
 
+  private$queue <- rrq_key_queue(keys$queue_id, queue)
+
   worker$log("ALIVE")
+  worker$log("QUEUE", queue)
 
   ## This announces that we're up; things may monitor this
   ## queue, and rrq_worker_spawn does a BLPOP to
@@ -460,10 +469,14 @@ worker_format <- function(worker) {
 }
 
 
-worker_log_format <- function(label, value) {
+worker_log_format <- function(label, value, is_child) {
   t <- Sys.time()
   ts <- as.character(t)
   td <- sprintf("%.04f", t) # to nearest 1/10000 s
+  if (is_child) {
+    ts <- sprintf("%s (%d)", ts, Sys.getpid())
+    td <- sprintf("%s/%d", td, Sys.getpid())
+  }
   if (is.null(value)) {
     str_redis <- sprintf("%s %s", td, label)
     str_screen <- sprintf("[%s] %s", ts, label)
@@ -481,8 +494,8 @@ worker_log_format <- function(label, value) {
 }
 
 
-worker_log <- function(con, keys, label, value, verbose) {
-  res <- worker_log_format(label, value)
+worker_log <- function(con, keys, label, value, is_child, verbose) {
+  res <- worker_log_format(label, value, is_child)
   if (verbose) {
     message(res$screen)
   }

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -99,10 +99,10 @@ worker_run_task_separate_process <- function(task, worker, private) {
 
 
 remote_run_task <- function(redis_config, queue_id, worker_id, task_id) {
-  worker_name <- sprintf("%s_%s", worker_id, ids::random_id(bytes = 4))
   con <- redux::hiredis(config = redis_config)
-  worker <- rrq_worker$new(queue_id, con, worker_name = worker_name,
-                           register = FALSE)
+  worker <- rrq_worker$new(queue_id, con, worker_name = worker_id,
+                           is_child = TRUE)
+  on.exit(worker$log("STOP", "OK"))
   worker$task_eval(task_id)
 }
 
@@ -111,7 +111,8 @@ worker_run_task_start <- function(worker, private, task_id) {
   keys <- private$keys
   name <- worker$name
   dat <- private$con$pipeline(
-    worker_log(redis, keys, "TASK_START", task_id, private$verbose),
+    worker_log(redis, keys, "TASK_START", task_id,
+               private$is_child, private$verbose),
     redis$HSET(keys$worker_status,   name,    WORKER_BUSY),
     redis$HSET(keys$worker_task,     name,    task_id),
     redis$HSET(keys$task_worker,     task_id, name),
@@ -149,7 +150,8 @@ worker_run_task_cleanup <- function(worker, private, status, value) {
   private$con$pipeline(
     redis$HSET(keys$worker_status,      name,    WORKER_IDLE),
     redis$HDEL(keys$worker_task,        name),
-    worker_log(redis, keys, log_status, task$task_id, private$verbose))
+    worker_log(redis, keys, log_status, task$task_id,
+               private$is_child, private$verbose))
 
   private$active_task <- NULL
   invisible()

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -1315,7 +1315,9 @@ all active workers are used.}
 \subsection{Method \code{worker_log_tail()}}{
 Returns the last (few) elements in the worker
 log. The log will be returned as a \link{data.frame} of entries
-\code{worker_id} (the worker id), \code{time} (the time in Redis when the
+\code{worker_id} (the worker id), \code{child} (the process id, an integer,
+where logs come from a child process from a task queued with
+\code{separate_process = TRUE}), \code{time} (the time in Redis when the
 event happened; see \link[redux:redis_time]{redux::redis_time} to convert this to an R
 time), \code{command} (the worker command) and \code{message} (the message
 corresponding to that command).

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -52,7 +52,7 @@ Constructor
   timeout_idle = NULL,
   heartbeat_period = NULL,
   verbose = TRUE,
-  register = TRUE,
+  is_child = FALSE,
   timeout_poll = 1,
   timeout_die = 2
 )}\if{html}{\out{</div>}}
@@ -97,11 +97,10 @@ measurable performance cost, and if you will not collect system
 logs from the worker then it is wasted time.  Logging to the
 redis server is always enabled.}
 
-\item{\code{register}}{Logical, indicating if the worker should be
-registered with the controller. Typically this is \code{TRUE}, but
-set to \code{FALSE} if you need to impersonate a worker, or create a
-temporary worker. This is passed as \code{FALSE} when running a task
-in a separate process.}
+\item{\code{is_child}}{Logical, used to indicate that this is a child of
+the real worker.  If \code{is_child} is \code{TRUE}, then most other
+arguments here have no effect (e.g., \code{queue} all the timeout /
+idle / polling arguments) as they come from the parent.}
 
 \item{\code{timeout_poll}}{Optional timeout indicating how long to wait
 for a background process to produce stdout or stderr. Only used

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -96,6 +96,16 @@ test_that("worker names can't be duplicated", {
 })
 
 
+test_that("Child workers require a parent", {
+  con <- test_hiredis()
+  name <- ids::random_id()
+  queue_id <- test_name(NULL)
+  expect_error(
+    rrq_worker$new(queue_id, con, worker_name = name, is_child = TRUE),
+    "Can't be a child of nonexistant worker")
+})
+
+
 test_that("Timer is recreated after task run", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)


### PR DESCRIPTION
This PR fixes the accumulation of junk worker logs, by interleaving logs from a child process with those from the parent. This should provide a much more consistent view of a task's progress as well as not littering the db with stuff.

There are a few minor bits of change to accommodate this, in particular the movement of where logging happens and a few tests that needed tweaking to account for that. In particular, we were previously deleting the worker log just after writing to it so a few messages were missed.

Fixes #60 