### PR TITLE
Simplify dependency handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.16
+Version: 0.6.17
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -39,7 +39,7 @@ queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
 }
 
 
-deferred_list <- function(con, keys, original) {
+deferred_list <- function(con, keys) {
   status <- redux::scan_find(con, "*", type = "HSCAN", key = keys$task_status)
   deferred_task_ids <- status[, "field"][status[, "value"] == TASK_DEFERRED]
   tmp <- rrq_key_task_depends_up_original(keys$queue_id, deferred_task_ids)

--- a/R/keys.R
+++ b/R/keys.R
@@ -48,9 +48,7 @@ rrq_keys_common <- function(queue_id) {
        task_time_submit   = sprintf("%s:task:time_submit",   queue_id),
        task_time_start    = sprintf("%s:task:time_start",    queue_id),
        task_time_complete = sprintf("%s:task:time_complete", queue_id),
-       task_time_moved    = sprintf("%s:task:time_moved",    queue_id),
-
-       deferred_set   = sprintf("%s:deferred", queue_id))
+       task_time_moved    = sprintf("%s:task:time_moved",    queue_id))
 }
 
 rrq_keys_worker <- function(queue, worker) {

--- a/R/keys.R
+++ b/R/keys.R
@@ -91,15 +91,14 @@ rrq_key_worker_alive <- function(queue_id) {
   sprintf("%s:worker:alive:%s", queue_id, ids::random_id())
 }
 
-rrq_key_task_dependencies <- function(queue_id, task_id) {
-  sprintf("%s:task:%s:dependencies", queue_id, task_id)
+rrq_key_task_depends_up <- function(queue_id, task_id) {
+  sprintf("%s:task:%s:depends:up", queue_id, task_id)
 }
 
-rrq_key_task_dependencies_original <- function(queue_id, task_id) {
-  sprintf("%s:task:%s:dependencies:original", queue_id, task_id)
+rrq_key_task_depends_up_original <- function(queue_id, task_id) {
+  sprintf("%s:task:%s:depends:up:original", queue_id, task_id)
 }
 
-## These are tasks that immediately depend on task_id
-rrq_key_task_dependents <- function(queue_id, task_id) {
-  sprintf("%s:task:%s:dependents", queue_id, task_id)
+rrq_key_task_depends_down <- function(queue_id, task_id) {
+  sprintf("%s:task:%s:depends:down", queue_id, task_id)
 }

--- a/R/keys.R
+++ b/R/keys.R
@@ -99,6 +99,7 @@ rrq_key_task_dependencies_original <- function(queue_id, task_id) {
   sprintf("%s:task:%s:dependencies:original", queue_id, task_id)
 }
 
+## These are tasks that immediately depend on task_id
 rrq_key_task_dependents <- function(queue_id, task_id) {
   sprintf("%s:task:%s:dependents", queue_id, task_id)
 }

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1404,10 +1404,10 @@ task_delete <- function(con, keys, store, task_ids, check) {
     }
   }
 
-  original_deps_keys <- rrq_key_task_dependencies_original(
+  original_deps_keys <- rrq_key_task_depends_up_original(
     keys$queue_id, task_ids_all)
-  dependency_keys <- rrq_key_task_dependencies(keys$queue_id, task_ids_all)
-  dependent_keys <- rrq_key_task_dependents(keys$queue_id, task_ids_all)
+  dependency_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids_all)
+  dependent_keys <- rrq_key_task_depends_down(keys$queue_id, task_ids_all)
   res <- con$pipeline(.commands = c(
     lapply(task_ids, function(x) redis$HGET(keys$task_status, x)),
     set_names(lapply(dependent_keys, redis$SMEMBERS), task_ids_all),
@@ -1529,10 +1529,10 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
       redis$HMSET(keys$task_timeout, task_ids, as.character(timeout)))
   }
 
-  original_deps_keys <- rrq_key_task_dependencies_original(
+  original_deps_keys <- rrq_key_task_depends_up_original(
     keys$queue_id, task_ids)
-  dependency_keys <- rrq_key_task_dependencies(keys$queue_id, task_ids)
-  dependent_keys <- rrq_key_task_dependents(keys$queue_id, depends_on)
+  dependency_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids)
+  dependent_keys <- rrq_key_task_depends_down(keys$queue_id, depends_on)
 
   if (!is.null(key_complete)) {
     cmds <- list(
@@ -2114,13 +2114,13 @@ is_task_redirect <- function(x) {
 
 
 task_depends_down <- function(con, keys, task_ids) {
-  key <- function(k) rrq_key_task_dependents(keys$queue_id, k)
+  key <- function(k) rrq_key_task_depends_down(keys$queue_id, k)
   task_depends_walk(con, key, task_ids)
 }
 
 
 task_depends_up <- function(con, keys, task_ids) {
-  key <- function(k) rrq_key_task_dependencies_original(keys$queue_id, k)
+  key <- function(k) rrq_key_task_depends_up_original(keys$queue_id, k)
   task_depends_walk(con, key, task_ids)
 }
 

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1419,7 +1419,6 @@ task_delete <- function(con, keys, store, task_ids, check) {
       redis$HDEL(keys$task_progress, task_ids_all),
       redis$HDEL(keys$task_worker,   task_ids_all),
       redis$HDEL(keys$task_local,    task_ids_all),
-      redis$SREM(keys$deferred_set,  task_ids_all),
       redis$DEL(original_deps_keys),
       redis$DEL(dependency_keys),
       redis$DEL(dependent_keys))))
@@ -1559,9 +1558,7 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
         redis$HMSET(keys$task_status, task_ids, rep_len(TASK_DEFERRED, n))),
       lapply(original_deps_keys, redis$SADD, depends_on),
       lapply(dependency_keys, redis$SADD, depends_on),
-      lapply(dependent_keys, redis$SADD, task_ids),
-      list(redis$SADD(keys$deferred_set, task_ids))
-    )
+      lapply(dependent_keys, redis$SADD, task_ids))
   } else {
     cmds <- c(cmds, list(redis$RPUSH(key_queue, task_ids)))
   }

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -10,8 +10,7 @@ run_task_cleanup <- function(con, keys, store, task_ids, status, value) {
       redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
       if (!is.null(key_complete)) {
         redis$RPUSH(key_complete, task_id)
-      },
-      redis$SREM(keys$deferred_set, task_id)
+      }
     )
   }
   cmds <- Map(cleanup_one, task_ids)

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -162,38 +162,38 @@ test_that("bulk tasks can be queued with dependency", {
   ## Original dependencies are stored
   grp_id_1 <- grp$task_ids[[1]]
   grp_id_2 <- grp$task_ids[[2]]
-  original_grp_dep_id_1 <- rrq_key_task_dependencies_original(
+  original_grp_dep_id_1 <- rrq_key_task_depends_up_original(
     obj$queue_id, grp_id_1)
   expect_setequal(obj$con$SMEMBERS(original_grp_dep_id_1), c(t, t2))
-  original_grp_dep_id_2 <- rrq_key_task_dependencies_original(
+  original_grp_dep_id_2 <- rrq_key_task_depends_up_original(
     obj$queue_id, grp_id_2)
   expect_setequal(obj$con$SMEMBERS(original_grp_dep_id_2), c(t, t2))
-  original_deps_keys_t3 <- rrq_key_task_dependencies_original(
+  original_deps_keys_t3 <- rrq_key_task_depends_up_original(
     obj$queue_id, t3)
   expect_setequal(obj$con$SMEMBERS(original_deps_keys_t3), grp$task_ids)
 
   ## Pending dependencies are stored
-  grp_dep_id_1 <- rrq_key_task_dependencies(obj$queue_id, grp_id_1)
+  grp_dep_id_1 <- rrq_key_task_depends_up(obj$queue_id, grp_id_1)
   expect_setequal(obj$con$SMEMBERS(grp_dep_id_1), c(t, t2))
-  grp_dep_id_2 <- rrq_key_task_dependencies(obj$queue_id, grp_id_2)
+  grp_dep_id_2 <- rrq_key_task_depends_up(obj$queue_id, grp_id_2)
   expect_setequal(obj$con$SMEMBERS(grp_dep_id_2), c(t, t2))
-  dependency_keys_t3 <- rrq_key_task_dependencies(obj$queue_id, t3)
+  dependency_keys_t3 <- rrq_key_task_depends_up(obj$queue_id, t3)
   expect_setequal(obj$con$SMEMBERS(dependency_keys_t3), grp$task_ids)
 
   ## Inverse depends_on relationship is stored
-  dependent_keys_t <- rrq_key_task_dependents(obj$queue_id, t)
+  dependent_keys_t <- rrq_key_task_depends_down(obj$queue_id, t)
   for (key in dependent_keys_t) {
     expect_setequal(obj$con$SMEMBERS(key), grp$task_ids)
   }
-  dependent_keys_t2 <- rrq_key_task_dependents(obj$queue_id, t2)
+  dependent_keys_t2 <- rrq_key_task_depends_down(obj$queue_id, t2)
   for (key in dependent_keys_t2) {
     expect_setequal(obj$con$SMEMBERS(key), grp$task_ids)
   }
-  grp_dependents_1 <- rrq_key_task_dependents(obj$queue_id, grp_id_1)
+  grp_dependents_1 <- rrq_key_task_depends_down(obj$queue_id, grp_id_1)
   for (key in grp_dependents_1) {
     expect_setequal(obj$con$SMEMBERS(key), t3)
   }
-  grp_dependents_2 <- rrq_key_task_dependents(obj$queue_id, grp_id_2)
+  grp_dependents_2 <- rrq_key_task_depends_down(obj$queue_id, grp_id_2)
   for (key in grp_dependents_2) {
     expect_setequal(obj$con$SMEMBERS(key), t3)
   }

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -198,10 +198,6 @@ test_that("bulk tasks can be queued with dependency", {
     expect_setequal(obj$con$SMEMBERS(key), t3)
   }
 
-  ## Items are in deferred queue
-  deferred_set <- queue_keys(obj)$deferred_set
-  expect_setequal(obj$con$SMEMBERS(deferred_set), c(grp$task_ids, t3))
-
   w$step(TRUE)
   obj$task_wait(t, 2)
   expect_equal(unname(obj$task_status(t)), "COMPLETE")
@@ -218,14 +214,12 @@ test_that("bulk tasks can be queued with dependency", {
   expect_equal(unname(obj$task_status(t3)), "DEFERRED")
   queue <- obj$queue_list()
   expect_setequal(queue, grp$task_ids)
-  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   obj$task_wait(queue[1], 2)
   expect_setequal(obj$task_status(grp$task_ids), c("COMPLETE", "PENDING"))
   expect_equal(unname(obj$task_status(t3)), "DEFERRED")
   expect_equal(obj$queue_list(), queue[2])
-  expect_equal(obj$con$SMEMBERS(deferred_set), list(t3))
 
   w$step(TRUE)
   obj$task_wait(queue[2], 2)
@@ -233,7 +227,6 @@ test_that("bulk tasks can be queued with dependency", {
                c("COMPLETE", "COMPLETE"))
   expect_equal(unname(obj$task_status(t3)), "PENDING")
   expect_equal(obj$queue_list(), t3)
-  expect_equal(obj$con$SMEMBERS(deferred_set), list())
 
   w$step(TRUE)
   obj$task_wait(t3, 2)

--- a/tests/testthat/test-rrq-retry.R
+++ b/tests/testthat/test-rrq-retry.R
@@ -50,7 +50,7 @@ test_that("Can't retry a task that has not been run", {
 })
 
 
-test_that("Can get deferred times", {
+test_that("Can get moved times", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
   set.seed(1)

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -510,16 +510,15 @@ test_that("task can be queued with dependency", {
   expect_equal(unname(obj$task_status(t3)), "DEFERRED")
 
   ## Original dependencies are stored
-  original_deps_keys <- rrq_key_task_dependencies_original(
-    obj$queue_id, t3)
+  original_deps_keys <- rrq_key_task_depends_up_original(obj$queue_id, t3)
   expect_setequal(obj$con$SMEMBERS(original_deps_keys), c(t, t2))
 
   ## Pending dependencies are stored
-  dependency_keys <- rrq_key_task_dependencies(obj$queue_id, t3)
+  dependency_keys <- rrq_key_task_depends_up(obj$queue_id, t3)
   expect_setequal(obj$con$SMEMBERS(dependency_keys), c(t, t2))
 
   ## Inverse depends_on relationship is stored
-  dependent_keys <- rrq_key_task_dependents(obj$queue_id, c(t, t2))
+  dependent_keys <- rrq_key_task_depends_down(obj$queue_id, c(t, t2))
   for (key in dependent_keys) {
     expect_equal(obj$con$SMEMBERS(key), list(t3))
   }

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -1069,7 +1069,7 @@ test_that("Can get information about a task in the same process", {
   expect_setequal(
     names(d1),
     c("id", "status", "queue", "separate_process", "timeout", "worker", "pid",
-      "moved"))
+      "moved", "depends"))
   expect_equal(d1$id, t)
   expect_equal(d1$status, TASK_PENDING)
   expect_equal(d1$queue, "default")
@@ -1078,6 +1078,7 @@ test_that("Can get information about a task in the same process", {
   expect_null(d1$worker)
   expect_null(d1$pid)
   expect_equal(d1$moved, list(up = NULL, down = NULL))
+  expect_equal(d1$depends, list(up = NULL, down = NULL))
 
   w$step(TRUE)
   d2 <- obj$task_info(t)
@@ -1089,7 +1090,8 @@ test_that("Can get information about a task in the same process", {
   expect_null(d2$timeout, 5)
   expect_equal(d2$worker, w$name)
   expect_null(d2$pid, "integer")
-  expect_equal(d1$moved, list(up = NULL, down = NULL))
+  expect_equal(d2$moved, list(up = NULL, down = NULL))
+  expect_equal(d2$depends, list(up = NULL, down = NULL))
 })
 
 
@@ -1103,7 +1105,7 @@ test_that("Can get information about a task in a different process", {
   expect_setequal(
     names(d1),
     c("id", "status", "queue", "separate_process", "timeout", "worker", "pid",
-      "moved"))
+      "moved", "depends"))
   expect_equal(d1$id, t)
   expect_equal(d1$status, TASK_PENDING)
   expect_equal(d1$queue, "default")
@@ -1112,6 +1114,7 @@ test_that("Can get information about a task in a different process", {
   expect_null(d1$worker)
   expect_null(d1$pid)
   expect_equal(d1$moved, list(up = NULL, down = NULL))
+  expect_equal(d1$depends, list(up = NULL, down = NULL))
 
   w$step(TRUE)
   d2 <- obj$task_info(t)
@@ -1123,7 +1126,8 @@ test_that("Can get information about a task in a different process", {
   expect_equal(d2$timeout, 5)
   expect_equal(d2$worker, w$name)
   expect_type(d2$pid, "integer")
-  expect_equal(d1$moved, list(up = NULL, down = NULL))
+  expect_equal(d2$moved, list(up = NULL, down = NULL))
+  expect_equal(d2$depends, list(up = NULL, down = NULL))
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -1284,18 +1284,31 @@ test_that("Can extract dependency information", {
   t4 <- obj$enqueue(identity(4), depends_on = c(t1, t2))
   t5 <- obj$enqueue(identity(4), depends_on = c(t4, t3))
 
-  expect_null(obj$task_info(t5)$depends$down)
-  expect_equal(obj$task_info(t4)$depends$down,
-               set_names(list(t5), t4))
-  expect_equal(obj$task_info(t3)$depends$down,
-               set_names(list(t5), t3))
-  expect_equal(obj$task_info(t2)$depends$down,
-               set_names(list(t4, t5), c(t2, t4)))
-  ## This one is the hard one:
-  deps1 <- obj$task_info(t1)$depends$down
-  expect_setequal(names(deps1), c(t1, t2, t3, t4))
-  expect_setequal(deps1[[t1]], c(t2, t3, t4))
-  expect_equal(deps1[[t2]], t4)
-  expect_equal(deps1[[t3]], t5)
-  expect_equal(deps1[[t4]], t5)
+  deps1 <- obj$task_info(t1)$depends
+  deps2 <- obj$task_info(t2)$depends
+  deps3 <- obj$task_info(t3)$depends
+  deps4 <- obj$task_info(t4)$depends
+  deps5 <- obj$task_info(t5)$depends
+
+  expect_null(deps1$up)
+  expect_setequal(names(deps1$down), c(t1, t2, t3, t4))
+  expect_setequal(deps1$down[[t1]], c(t2, t3, t4))
+
+  expect_equal(deps2$up, set_names(list(t1), t2))
+  expect_equal(deps2$down, set_names(list(t4, t5), c(t2, t4)))
+
+  expect_equal(deps3$up, set_names(list(t1), t3))
+  expect_equal(deps3$down, set_names(list(t5), t3))
+
+  expect_setequal(names(deps4$up), c(t4, t2))
+  expect_equal(deps4$up[[t4]], c(t1, t2))
+  expect_equal(deps4$up[[t2]], deps2$up[[t2]])
+  expect_equal(deps4$down, set_names(list(t5), t4))
+
+  expect_setequal(names(deps5$up), c(t5, t4, t3, t2))
+  expect_equal(deps5$up[[t5]], c(t4, t3))
+  expect_equal(deps5$up[[t4]], deps4$up[[t4]])
+  expect_equal(deps5$up[[t3]], deps3$up[[t3]])
+  expect_equal(deps5$up[[t2]], deps2$up[[t2]])
+  expect_null(deps5$depends$down)
 })

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -1301,12 +1301,12 @@ test_that("Can extract dependency information", {
   expect_equal(deps3$down, set_names(list(t5), t3))
 
   expect_setequal(names(deps4$up), c(t4, t2))
-  expect_equal(deps4$up[[t4]], c(t1, t2))
+  expect_setequal(deps4$up[[t4]], c(t1, t2))
   expect_equal(deps4$up[[t2]], deps2$up[[t2]])
   expect_equal(deps4$down, set_names(list(t5), t4))
 
   expect_setequal(names(deps5$up), c(t5, t4, t3, t2))
-  expect_equal(deps5$up[[t5]], c(t4, t3))
+  expect_setequal(deps5$up[[t5]], c(t4, t3))
   expect_equal(deps5$up[[t4]], deps4$up[[t4]])
   expect_equal(deps5$up[[t3]], deps3$up[[t3]])
   expect_equal(deps5$up[[t2]], deps2$up[[t2]])


### PR DESCRIPTION
This PR simplifies handling of querying dependencies:

* dependents/dependencies becomes "depends down" and "depends up", reflecting moved up and moved down in the task retrying
* add information about dependencies to the task info
* remove the deferred set in favour of computing this at the point of asking