### PR TITLE
Consistent, nonrecursive, dependency handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.17
+Version: 0.6.18
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,20 +1,3 @@
-get_dependent_ids <- function(con, queue_id, task_id) {
-  dependent_keys <- rrq_key_task_depends_down(queue_id, task_id)
-  con$SMEMBERS(dependent_keys)
-}
-
-cancel_dependencies <- function(con, keys, store, ids) {
-  dependent_keys <- rrq_key_task_depends_down(keys$queue_id, ids)
-  dependent_ids <- unique(unlist(lapply(dependent_keys, con$SMEMBERS)))
-  n <- length(dependent_ids)
-
-  run_task_cleanup(con, keys, store, dependent_ids, TASK_IMPOSSIBLE, NULL)
-
-  if (n > 0) {
-    cancel_dependencies(con, keys, store, dependent_ids)
-  }
-}
-
 queue_dependencies <- function(con, keys, task_id, deferred_task_ids) {
   dependency_keys <- rrq_key_task_depends_up(keys$queue_id, deferred_task_ids)
   res <- con$pipeline(.commands = c(

--- a/R/heartbeat.R
+++ b/R/heartbeat.R
@@ -47,9 +47,7 @@ cleanup_orphans <- function(con, keys, store, time) {
       "Orphaning %s %s:\n%s",
       length(task_ids), ngettext(sum(i), "task", "tasks"),
       paste0("  - ", task_ids, collapse = "\n")))
-    for (id in task_ids) {
-      run_task_cleanup(con, keys, store, id, TASK_DIED, NULL)
-    }
+    run_task_cleanup_failure(con, keys, store, task_ids, TASK_DIED, NULL)
   }
 
   con$HMSET(keys$worker_status, worker_id, rep(WORKER_LOST, length(worker_id)))

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1584,7 +1584,7 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
   ## In the time between 2 and 3 A could have finished and failed meaning that
   ## the dependency of B will never be satisfied and it will never be run.
   if (any(response$status %in% TASK$terminal_fail)) {
-    run_task_cleanup(con, keys, store, task_ids, TASK_IMPOSSIBLE, NULL)
+    run_task_cleanup_failure(con, keys, store, task_ids, TASK_IMPOSSIBLE, NULL)
     incomplete <- response$status[response$status %in% TASK$terminal_fail]
     names(incomplete) <- depends_on[response$status %in% TASK$terminal_fail]
     stop(sprintf("Failed to queue as dependent tasks failed:\n%s",

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -862,24 +862,23 @@ rrq_controller <- R6::R6Class(
     },
 
     ##' @description Cancel a single task. If the task is `PENDING` it
-    ##' will be deleted. If `RUNNING` then the task will be stopped if
-    ##' it was set to run in a separate process (i.e., queued with
-    ##' `separate_process = TRUE`). Dependent tasks will be marked as
-    ##' impossible.
+    ##' will be unqueued and the status set to `CANCELED`.  If `RUNNING`
+    ##' then the task will be stopped if it was set to run in
+    ##' a separate process (i.e., queued with `separate_process = TRUE`).
+    ##' Dependent tasks will be marked as impossible.
     ##'
     ##' @param task_id Id of the task to cancel
     ##'
-    ##' @param wait Wait for the task to be stopped, if it was running. If
-    ##'   `delete` is `TRUE`, then we will always wait for the task to stop.
+    ##' @param wait Wait for the task to be stopped, if it was running.
     ##'
-    ##' @param delete Delete the task after cancelling (if cancelling
-    ##'   was successful).
+    ##' @param timeout_wait Maximum time, in seconds, to wait for the task
+    ##'   to be cancelled by the worker.
     ##'
     ##' @return Nothing if successfully cancelled, otherwise throws an
     ##' error with task_id and status e.g. Task 123 is not running (MISSING)
-    task_cancel = function(task_id, wait = TRUE, delete = TRUE) {
+    task_cancel = function(task_id, wait = TRUE, timeout_wait = 10) {
       task_cancel(self$con, private$keys, private$store, private$scripts,
-                  task_id, wait, delete)
+                  task_id, wait, timeout_wait)
     },
 
     ##' @description Fetch internal data about a task from Redis
@@ -1404,24 +1403,24 @@ task_delete <- function(con, keys, store, task_ids, check) {
     }
   }
 
-  original_deps_keys <- rrq_key_task_depends_up_original(
+  depends_up_original_keys <- rrq_key_task_depends_up_original(
     keys$queue_id, task_ids_all)
-  dependency_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids_all)
-  dependent_keys <- rrq_key_task_depends_down(keys$queue_id, task_ids_all)
-  res <- con$pipeline(.commands = c(
-    lapply(task_ids, function(x) redis$HGET(keys$task_status, x)),
-    set_names(lapply(dependent_keys, redis$SMEMBERS), task_ids_all),
-    list(
-      redis$HDEL(keys$task_expr,     task_ids_all),
-      redis$HDEL(keys$task_status,   task_ids_all),
-      redis$HDEL(keys$task_result,   task_ids_all),
-      redis$HDEL(keys$task_complete, task_ids_all),
-      redis$HDEL(keys$task_progress, task_ids_all),
-      redis$HDEL(keys$task_worker,   task_ids_all),
-      redis$HDEL(keys$task_local,    task_ids_all),
-      redis$DEL(original_deps_keys),
-      redis$DEL(dependency_keys),
-      redis$DEL(dependent_keys))))
+  depends_up_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids_all)
+  depends_down_keys <- rrq_key_task_depends_down(keys$queue_id, task_ids_all)
+  res <- con$pipeline(
+    .commands = c(
+      lapply(depends_down_keys, redis$SCARD),
+      list(
+        redis$HMGET(keys$task_status,  task_ids_all),
+        redis$HDEL(keys$task_expr,     task_ids_all),
+        redis$HDEL(keys$task_status,   task_ids_all),
+        redis$HDEL(keys$task_result,   task_ids_all),
+        redis$HDEL(keys$task_complete, task_ids_all),
+        redis$HDEL(keys$task_progress, task_ids_all),
+        redis$HDEL(keys$task_worker,   task_ids_all),
+        redis$HDEL(keys$task_local,    task_ids_all),
+        redis$DEL(depends_up_original_keys),
+        redis$DEL(depends_up_keys))))
 
   queue <- list_to_character(con$HMGET(keys$task_queue, task_ids_root))
   queue_remove(con, keys, task_ids_all, queue)
@@ -1432,23 +1431,34 @@ task_delete <- function(con, keys, store, task_ids, check) {
   ## A. They are dependents of a task which is PENDING or DEFERRED AND
   ## B. Their dependencies have not already been deleted or set to ERRORED, etc.
   ## i.e. their dependencies are also DEFERRED
-  status <- res[seq_along(task_ids_all)]
-  ids_to_cancel <- task_ids_all[unlist(status) %in% TASK$unstarted]
-  dependents <- unique(unlist(res[ids_to_cancel]))
-  if (length(dependents) > 0) {
-    status_dependent <- con$HMGET(keys$task_status, dependents)
-    cancel <- dependents[status_dependent == TASK_DEFERRED]
-    if (length(cancel) > 0) {
-      run_task_cleanup(con, keys, store, cancel, TASK_IMPOSSIBLE, NULL)
-      cancel_dependencies(con, keys, store, cancel)
+  n <- length(task_ids_all)
+  check_dependencies <-
+    (list_to_numeric(res[seq_len(n)]) > 0) &
+    vlapply(res[[n + 1]], function(x) !is.null(x) && x %in% TASK$unstarted)
+  if (any(check_dependencies)) {
+    ids_all_deps <- unlist(
+      task_depends_down(con, keys, task_ids_all[check_dependencies]),
+      FALSE, FALSE)
+    ids_deps <- setdiff(ids_all_deps, task_ids_all)
+    status_deps <- task_status(con, keys, ids_deps, follow = FALSE)
+    ids_impossible <- ids_deps[status_deps == TASK_DEFERRED]
+    if (length(ids_impossible) > 0) {
+      run_task_cleanup_failure(con, keys, store, ids_impossible,
+                               TASK_IMPOSSIBLE, NULL)
     }
   }
+
+  con$DEL(depends_down_keys)
 
   invisible()
 }
 
-task_cancel <- function(con, keys, store, scripts, task_id, wait = FALSE,
-                        delete = TRUE) {
+task_cancel <- function(con, keys, store, scripts, task_id, wait,
+                        timeout_wait) {
+  assert_scalar_character(task_id)
+  assert_scalar_logical(wait)
+  assert_valid_timeout(timeout_wait)
+
   ## There are several steps here, which will all be executed in one
   ## block which removes the possibility of race conditions:
   ##
@@ -1465,33 +1475,33 @@ task_cancel <- function(con, keys, store, scripts, task_id, wait = FALSE,
   ##
   ## * Retrieve the status so that we know the task status before any
   ##   change can happen.
+  ##
+  ## Unfortunately it's not possible to also cancel dependencies in a
+  ## race-free way and we'll tidy that up later.
+  key_queue <- rrq_key_queue(keys$queue_id, con$HGET(keys$task_queue, task_id))
+
   dat <- con$pipeline(
-    dropped = redis$EVALSHA(scripts$queue_delete, 1L, keys$task_queue, task_id),
+    dropped = redis$LREM(key_queue, 1, task_id),
     cancel = redis$HSET(keys$task_cancel, task_id, "TRUE"),
     status = redis$HGET(keys$task_status, task_id),
-    local = redis$HGET(keys$task_local, task_id))
+    local = redis$HGET(keys$task_local, task_id),
+    n_deps = redis$SCARD(rrq_key_task_depends_down(keys$queue_id, task_id)))
 
   task_status <- dat$status %||% TASK_MISSING
-
   if (!(task_status %in% TASK$unfinished)) {
     stop(sprintf("Task %s is not cancelable (%s)", task_id, task_status))
   }
-
-  cancel_dependencies(con, keys, store, task_id)
 
   if (task_status == TASK_RUNNING) {
     if (dat$local != "FALSE") {
       stop(sprintf(
         "Can't cancel running task '%s' as not in separate process", task_id))
     }
-    if (delete || wait) {
-      timeout_wait <- 10
+    if (wait) {
       wait_status_change(con, keys, task_id, TASK_RUNNING, timeout_wait)
     }
-  }
-
-  if (delete) {
-    task_delete(con, keys, store, task_id, FALSE)
+  } else {
+    run_task_cleanup_failure(con, keys, store, task_id, TASK_CANCELLED, NULL)
   }
 
   invisible(NULL)
@@ -1528,10 +1538,10 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
       redis$HMSET(keys$task_timeout, task_ids, as.character(timeout)))
   }
 
-  original_deps_keys <- rrq_key_task_depends_up_original(
+  depends_up_original_keys <- rrq_key_task_depends_up_original(
     keys$queue_id, task_ids)
-  dependency_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids)
-  dependent_keys <- rrq_key_task_depends_down(keys$queue_id, depends_on)
+  depends_up_keys <- rrq_key_task_depends_up(keys$queue_id, task_ids)
+  depends_down_keys <- rrq_key_task_depends_down(keys$queue_id, depends_on)
 
   if (!is.null(key_complete)) {
     cmds <- list(
@@ -1556,9 +1566,9 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
       list(
         status = redis$HMGET(keys$task_status, depends_on),
         redis$HMSET(keys$task_status, task_ids, rep_len(TASK_DEFERRED, n))),
-      lapply(original_deps_keys, redis$SADD, depends_on),
-      lapply(dependency_keys, redis$SADD, depends_on),
-      lapply(dependent_keys, redis$SADD, task_ids))
+      lapply(depends_up_original_keys, redis$SADD, depends_on),
+      lapply(depends_up_keys, redis$SADD, depends_on),
+      lapply(depends_down_keys, redis$SADD, task_ids))
   } else {
     cmds <- c(cmds, list(redis$RPUSH(key_queue, task_ids)))
   }
@@ -1575,7 +1585,6 @@ task_submit_n <- function(con, keys, store, task_ids, dat, key_complete, queue,
   ## the dependency of B will never be satisfied and it will never be run.
   if (any(response$status %in% TASK$terminal_fail)) {
     run_task_cleanup(con, keys, store, task_ids, TASK_IMPOSSIBLE, NULL)
-    cancel_dependencies(con, keys, store, task_ids)
     incomplete <- response$status[response$status %in% TASK$terminal_fail]
     names(incomplete) <- depends_on[response$status %in% TASK$terminal_fail]
     stop(sprintf("Failed to queue as dependent tasks failed:\n%s",

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1484,8 +1484,7 @@ task_cancel <- function(con, keys, store, scripts, task_id, wait,
     dropped = redis$LREM(key_queue, 1, task_id),
     cancel = redis$HSET(keys$task_cancel, task_id, "TRUE"),
     status = redis$HGET(keys$task_status, task_id),
-    local = redis$HGET(keys$task_local, task_id),
-    n_deps = redis$SCARD(rrq_key_task_depends_down(keys$queue_id, task_id)))
+    local = redis$HGET(keys$task_local, task_id))
 
   task_status <- dat$status %||% TASK_MISSING
   if (!(task_status %in% TASK$unfinished)) {

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -1,12 +1,3 @@
-run_task_cleanup <- function(con, keys, store, task_id, status, value) {
-  if (status == TASK_COMPLETE) {
-    run_task_cleanup_success(con, keys, store, task_id, status, value)
-  } else {
-    run_task_cleanup_failure(con, keys, store, task_id, status, value)
-  }
-}
-
-
 run_task_cleanup_success <- function(con, keys, store, task_id, status, value) {
   task_result <- store$set(value, task_id)
   key_complete <- con$HGET(keys$task_complete, task_id)
@@ -27,6 +18,9 @@ run_task_cleanup_success <- function(con, keys, store, task_id, status, value) {
 }
 
 
+## NOTE: unlike the success path (which is guaranteed to be a single
+## task, single result) the failure path must be vectorised as we'll
+## do bulk deletions quite frequently.
 run_task_cleanup_failure <- function(con, keys, store, task_ids, status,
                                      value) {
   ## TODO: we can do this more efficiently with some HMSET commands, I think

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -1,5 +1,36 @@
-run_task_cleanup <- function(con, keys, store, task_ids, status, value) {
-  cleanup_one <- function(task_id) {
+run_task_cleanup <- function(con, keys, store, task_id, status, value) {
+  if (status == TASK_COMPLETE) {
+    run_task_cleanup_success(con, keys, store, task_id, status, value)
+  } else {
+    run_task_cleanup_failure(con, keys, store, task_id, status, value)
+  }
+}
+
+
+run_task_cleanup_success <- function(con, keys, store, task_id, status, value) {
+  task_result <- store$set(value, task_id)
+  key_complete <- con$HGET(keys$task_complete, task_id)
+  key_depends_down <- rrq_key_task_depends_down(keys$queue_id, task_id)
+  res <- con$pipeline(
+    redis$HSET(keys$task_result,        task_id, task_result),
+    redis$HSET(keys$task_status,        task_id, status),
+    redis$HSET(keys$task_time_complete, task_id, timestamp()),
+    redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
+    if (!is.null(key_complete)) {
+      redis$RPUSH(key_complete, task_id)
+    },
+    redis$SMEMBERS(key_depends_down))
+  depends_down <- last(res)
+  if (length(depends_down)) {
+    queue_dependencies(con, keys, task_id, depends_down)
+  }
+}
+
+
+run_task_cleanup_failure <- function(con, keys, store, task_ids, status,
+                                     value) {
+  ## TODO: we can do this more efficiently with some HMSET commands, I think
+  cleanup_one <- function(task_id, status, value) {
     value <- value %||% worker_task_failed(status, keys$queue_id, task_id)
     task_result <- store$set(value, task_id)
     key_complete <- con$HGET(keys$task_complete, task_id)
@@ -10,9 +41,20 @@ run_task_cleanup <- function(con, keys, store, task_ids, status, value) {
       redis$RPUSH(rrq_key_task_complete(keys$queue_id, task_id), task_id),
       if (!is.null(key_complete)) {
         redis$RPUSH(key_complete, task_id)
-      }
-    )
+      })
   }
-  cmds <- Map(cleanup_one, task_ids)
+
+  ## This is not quite right, dependent tasks need to go in as IMPOSSIBLE
+  task_ids_all <- union(
+    task_ids,
+    unlist(task_depends_down(con, keys, task_ids), FALSE, FALSE))
+  if (length(task_ids) < length(task_ids_all)) {
+    n <- c(length(task_ids), length(task_ids_all) - length(task_ids))
+    status <- rep(c(status, TASK_IMPOSSIBLE), n)
+    value <- rep(list(value, NULL), n)
+  } else {
+    value <- rep(list(value), length(task_ids))
+  }
+  cmds <- Map(cleanup_one, task_ids_all, status, value)
   con$pipeline(.commands = unlist(cmds, FALSE, FALSE))
 }

--- a/R/task_cleanup.R
+++ b/R/task_cleanup.R
@@ -38,7 +38,6 @@ run_task_cleanup_failure <- function(con, keys, store, task_ids, status,
       })
   }
 
-  ## This is not quite right, dependent tasks need to go in as IMPOSSIBLE
   task_ids_all <- union(
     task_ids,
     unlist(task_depends_down(con, keys, task_ids), FALSE, FALSE))

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,6 +74,11 @@ list_to_character <- function(x) {
 }
 
 
+list_to_numeric <- function(x) {
+  vnapply(x, identity)
+}
+
+
 data_frame <- function(...) {
   data.frame(..., stringsAsFactors = FALSE)
 }
@@ -232,4 +237,9 @@ first <- function(x) {
 
 last <- function(x) {
   x[[length(x)]]
+}
+
+
+rep_along <- function(x, v) {
+  rep_len(x, length(v))
 }

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -8,16 +8,18 @@ worker_run_task <- function(worker, private, task_id) {
 
   con <- private$con
   keys <- private$keys
+  store <- private$store
+  status <- res$status
   if (status == TASK_COMPLETE) {
-    run_task_cleanup_success(con, keys, store, task_id, res$status, res$value)
+    run_task_cleanup_success(con, keys, store, task_id, status, res$value)
   } else {
-    run_task_cleanup_failure(con, keys, store, task_id, res$status, res$value)
+    run_task_cleanup_failure(con, keys, store, task_id, status, res$value)
   }
 
   con$pipeline(
     redis$HSET(keys$worker_status, worker$name, WORKER_IDLE),
     redis$HDEL(keys$worker_task,   worker$name),
-    worker_log(redis, keys, paste0("TASK_", res$status), task_id,
+    worker_log(redis, keys, paste0("TASK_", status), task_id,
                private$is_child, private$verbose))
 
   private$active_task <- NULL

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -8,7 +8,11 @@ worker_run_task <- function(worker, private, task_id) {
 
   con <- private$con
   keys <- private$keys
-  run_task_cleanup(con, keys, private$store, task_id, res$status, res$value)
+  if (status == TASK_COMPLETE) {
+    run_task_cleanup_success(con, keys, store, task_id, res$status, res$value)
+  } else {
+    run_task_cleanup_failure(con, keys, store, task_id, res$status, res$value)
+  }
 
   con$pipeline(
     redis$HSET(keys$worker_status, worker$name, WORKER_IDLE),


### PR DESCRIPTION
This PR tidies up how we do dependency handling, ahead of refactoring to use lua scripts for most of it. In particular, there are no mutually recursive calls any more, with the only bit of recursion being the dependency finding.

This was much more fiddly to write than the line count suggests, and has at least one visible change in behaviour - cancelling a task no longer deletes it (this was a very odd choice, not sure why we'd have wanted that)