### PR TITLE
Mass rename from worker name to id

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.18
+Version: 0.6.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/heartbeat.R
+++ b/R/heartbeat.R
@@ -51,7 +51,7 @@ cleanup_orphans <- function(con, keys, store, time) {
   }
 
   con$HMSET(keys$worker_status, worker_id, rep(WORKER_LOST, length(worker_id)))
-  con$SREM(keys$worker_name, worker_id)
+  con$SREM(keys$worker_id, worker_id)
 
   invisible(task_ids)
 }

--- a/R/keys.R
+++ b/R/keys.R
@@ -1,9 +1,9 @@
-rrq_keys <- function(queue_id, worker_name = NULL) {
-  if (is.null(worker_name)) {
+rrq_keys <- function(queue_id, worker_id = NULL) {
+  if (is.null(worker_id)) {
     rrq_keys_common(queue_id)
   } else {
     c(rrq_keys_common(queue_id),
-      rrq_keys_worker(queue_id, worker_name))
+      rrq_keys_worker(queue_id, worker_id))
   }
 }
 
@@ -18,7 +18,7 @@ rrq_keys_common <- function(queue_id) {
        envir          = sprintf("%s:envir",          queue_id),
 
        worker_config       = sprintf("%s:worker:config",       queue_id),
-       worker_name         = sprintf("%s:worker:name",         queue_id),
+       worker_id           = sprintf("%s:worker:id",           queue_id),
        worker_status       = sprintf("%s:worker:status",       queue_id),
        worker_task         = sprintf("%s:worker:task",         queue_id),
        worker_info         = sprintf("%s:worker:info",         queue_id),

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -1633,10 +1633,10 @@ tasks_result <- function(con, keys, store, task_ids, error, follow, single) {
 }
 
 worker_len <- function(con, keys) {
-  con$SCARD(keys$worker_name)
+  con$SCARD(keys$worker_id)
 }
 worker_list <- function(con, keys) {
-  worker_naturalsort(as.character(con$SMEMBERS(keys$worker_name)))
+  worker_naturalsort(as.character(con$SMEMBERS(keys$worker_id)))
 }
 
 worker_list_exited <- function(con, keys) {
@@ -1720,7 +1720,7 @@ worker_delete_exited <- function(con, keys, worker_ids = NULL) {
   }
 
   if (length(worker_ids) > 0L) {
-    con$SREM(keys$worker_name,   worker_ids)
+    con$SREM(keys$worker_id,     worker_ids)
     con$HDEL(keys$worker_status, worker_ids)
     con$HDEL(keys$worker_task,   worker_ids)
     con$HDEL(keys$worker_info,   worker_ids)

--- a/R/worker_messages.R
+++ b/R/worker_messages.R
@@ -60,7 +60,7 @@ run_message_stop <- function(worker, private, message_id, args) {
 
 run_message_info <- function(worker, private) {
   info <- worker$info()
-  private$con$HSET(private$keys$worker_info, worker$name, object_to_bin(info))
+  private$con$HSET(private$keys$worker_info, worker$id, object_to_bin(info))
   info
 }
 
@@ -74,7 +74,7 @@ run_message_pause <- function(worker, private) {
     "NOOP"
   } else {
     private$paused <- TRUE
-    private$con$HSET(private$keys$worker_status, worker$name, WORKER_PAUSED)
+    private$con$HSET(private$keys$worker_status, worker$id, WORKER_PAUSED)
     "OK"
   }
 }
@@ -82,7 +82,7 @@ run_message_pause <- function(worker, private) {
 run_message_resume <- function(worker, private) {
   if (private$paused) {
     private$paused <- FALSE
-    private$con$HSET(private$keys$worker_status, worker$name, WORKER_IDLE)
+    private$con$HSET(private$keys$worker_status, worker$id, WORKER_IDLE)
     "OK"
   } else {
     "NOOP"

--- a/R/worker_runner.R
+++ b/R/worker_runner.R
@@ -25,7 +25,7 @@
 ##'
 ##' * `queue_id` as the sole positional argument
 ##' * `worker_config` as `--config`
-##' * `worker_name` as `--name`
+##' * `worker_id` as `--id`
 ##' * `key_alive` as `--key-alive`
 ##'
 ##' To change the redis connection settings, set the `REDIS_URL`
@@ -35,7 +35,7 @@
 ##' `myconfig` on queue `myqueue` you might use
 ##'
 ##' ```
-##' ./rrq_worker --config=myconfig --name=myworker myqueue
+##' ./rrq_worker --config=myconfig --id=myworker myqueue
 ##' ```
 ##'
 ##' @title Write worker runner script
@@ -74,7 +74,7 @@ rrq_worker_script <- function(path, versioned = FALSE) {
 
 rrq_worker_main <- function(args = commandArgs(TRUE)) {
   dat <- rrq_worker_main_args(args)
-  worker <- rrq_worker_from_config(dat$queue_id, dat$config, dat$name,
+  worker <- rrq_worker_from_config(dat$queue_id, dat$config, dat$id,
                                    dat$key_alive)
   worker$loop()
   invisible()
@@ -87,13 +87,13 @@ rrq_worker_main_args <- function(args) {
 
 Options:
 --config=NAME    Name of a worker configuration [default: localhost]
---name=NAME      Name of the worker (optional)
+--id=ID          Id of the worker (optional)
 --key-alive=KEY  Key to write to once alive (optional)"
   dat <- docopt::docopt(doc, args)
   names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
   list(queue_id = dat$id,
        config = dat$config,
-       name = dat$name,
+       id = dat$id,
        key_alive = dat[["key_alive"]])
 }
 

--- a/R/worker_runner.R
+++ b/R/worker_runner.R
@@ -25,7 +25,7 @@
 ##'
 ##' * `queue_id` as the sole positional argument
 ##' * `worker_config` as `--config`
-##' * `worker_id` as `--id`
+##' * `worker_id` as `--worker-id`
 ##' * `key_alive` as `--key-alive`
 ##'
 ##' To change the redis connection settings, set the `REDIS_URL`
@@ -35,7 +35,7 @@
 ##' `myconfig` on queue `myqueue` you might use
 ##'
 ##' ```
-##' ./rrq_worker --config=myconfig --id=myworker myqueue
+##' ./rrq_worker --config=myconfig --worker-id=myworker myqueue
 ##' ```
 ##'
 ##' @title Write worker runner script
@@ -74,7 +74,7 @@ rrq_worker_script <- function(path, versioned = FALSE) {
 
 rrq_worker_main <- function(args = commandArgs(TRUE)) {
   dat <- rrq_worker_main_args(args)
-  worker <- rrq_worker_from_config(dat$queue_id, dat$config, dat$id,
+  worker <- rrq_worker_from_config(dat$queue_id, dat$config, dat$worker_id,
                                    dat$key_alive)
   worker$loop()
   invisible()
@@ -87,13 +87,13 @@ rrq_worker_main_args <- function(args) {
 
 Options:
 --config=NAME    Name of a worker configuration [default: localhost]
---id=ID          Id of the worker (optional)
+--worker-id=ID   Id of the worker (optional)
 --key-alive=KEY  Key to write to once alive (optional)"
   dat <- docopt::docopt(doc, args)
   names(dat) <- gsub("-", "_", names(dat), fixed = TRUE)
   list(queue_id = dat$id,
        config = dat$config,
-       id = dat$id,
+       worker_id = dat$worker_id,
        key_alive = dat[["key_alive"]])
 }
 

--- a/R/worker_spawn.R
+++ b/R/worker_spawn.R
@@ -23,8 +23,9 @@
 ##' @param worker_config Name of the configuration to use.  By default
 ##'   the \code{"localhost"} configuration is used
 ##'
-##' @param worker_name_base Optional base to construct the worker
-##'   names from.  If omitted a random name will be used.
+##' @param worker_id_base Optional base to construct the worker ids
+##'   from.  If omitted a random base will be used. Actual ids will be
+##'   created but appending integers to this base.
 ##'
 ##' @param time_poll Polling period (in seconds) while waiting for
 ##'   workers to come up.  Must be an integer, at least 1.
@@ -35,7 +36,7 @@
 ##' @export
 rrq_worker_spawn <- function(obj, n = 1, logdir = NULL,
                              timeout = 600, worker_config = "localhost",
-                             worker_name_base = NULL,
+                             worker_id_base = NULL,
                              time_poll = 1, progress = NULL) {
   assert_is(obj, "rrq_controller")
   if (!(worker_config %in% obj$worker_config_list())) {
@@ -45,25 +46,25 @@ rrq_worker_spawn <- function(obj, n = 1, logdir = NULL,
   rrq_worker <- rrq_worker_script(tempfile(), versioned = TRUE)
   env <- paste0("RLIBS=", paste(.libPaths(), collapse = ":"),
                 ' R_TESTS=""')
-  worker_name_base <- worker_name_base %||% ids::adjective_animal()
-  worker_names <- sprintf("%s_%d", worker_name_base, seq_len(n))
-  key_alive <- rrq_expect_worker(obj, worker_names)
+  worker_id_base <- worker_id_base %||% ids::adjective_animal()
+  worker_ids <- sprintf("%s_%d", worker_id_base, seq_len(n))
+  key_alive <- rrq_expect_worker(obj, worker_ids)
 
   ## log files for the process
   logdir <- logdir %||% tempfile()
   dir.create(logdir, FALSE, TRUE)
-  logfile <- file.path(logdir, worker_names)
+  logfile <- file.path(logdir, worker_ids)
 
   message(sprintf("Spawning %d %s with prefix %s",
-                  n, ngettext(n, "worker", "workers"), worker_name_base))
+                  n, ngettext(n, "worker", "workers"), worker_id_base))
 
   keys <- rrq_keys(obj$queue_id)
-  obj$con$HMSET(keys$worker_process, worker_names, logfile)
+  obj$con$HMSET(keys$worker_process, worker_ids, logfile)
 
   for (i in seq_len(n)) {
     args <- c(obj$queue_id,
               "--config", worker_config,
-              "--name", worker_names[[i]],
+              "--id", worker_ids[[i]],
               "--key-alive", key_alive)
     system2(rrq_worker, args, env = env, wait = FALSE,
             stdout = logfile[[i]], stderr = logfile[[i]])
@@ -73,7 +74,7 @@ rrq_worker_spawn <- function(obj, n = 1, logdir = NULL,
     rrq_worker_wait(obj, key_alive, timeout, time_poll, progress)
   } else {
     list(key_alive = key_alive,
-         names = worker_names)
+         ids = worker_ids)
   }
 }
 
@@ -122,13 +123,13 @@ rrq_worker_wait <- function(obj, key_alive, timeout = 600, time_poll = 1,
 ##' \code{rrq_worker_spawn}).
 ##' @title Register expected workers
 ##' @param obj A rrq_controller object
-##' @param names Names of expected workers
+##' @param ids Ids of expected workers
 ##' @export
-rrq_expect_worker <- function(obj, names) {
+rrq_expect_worker <- function(obj, ids) {
   assert_is(obj, "rrq_controller")
   key_alive <- rrq_key_worker_alive(obj$queue_id)
   keys <- rrq_keys(obj$queue_id)
-  obj$con$HSET(keys$worker_expect, key_alive, object_to_bin(names))
+  obj$con$HSET(keys$worker_expect, key_alive, object_to_bin(ids))
   key_alive
 }
 

--- a/R/worker_spawn.R
+++ b/R/worker_spawn.R
@@ -64,7 +64,7 @@ rrq_worker_spawn <- function(obj, n = 1, logdir = NULL,
   for (i in seq_len(n)) {
     args <- c(obj$queue_id,
               "--config", worker_config,
-              "--id", worker_ids[[i]],
+              "--worker-id", worker_ids[[i]],
               "--key-alive", key_alive)
     system2(rrq_worker, args, env = env, wait = FALSE,
             stdout = logfile[[i]], stderr = logfile[[i]])

--- a/man/rrq_controller.Rd
+++ b/man/rrq_controller.Rd
@@ -1166,12 +1166,12 @@ desirable behaviour.}
 \if{latex}{\out{\hypertarget{method-rrq_controller-task_cancel}{}}}
 \subsection{Method \code{task_cancel()}}{
 Cancel a single task. If the task is \code{PENDING} it
-will be deleted. If \code{RUNNING} then the task will be stopped if
-it was set to run in a separate process (i.e., queued with
-\code{separate_process = TRUE}). Dependent tasks will be marked as
-impossible.
+will be unqueued and the status set to \code{CANCELED}.  If \code{RUNNING}
+then the task will be stopped if it was set to run in
+a separate process (i.e., queued with \code{separate_process = TRUE}).
+Dependent tasks will be marked as impossible.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_cancel(task_id, wait = TRUE, delete = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{rrq_controller$task_cancel(task_id, wait = TRUE, timeout_wait = 10)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1179,11 +1179,10 @@ impossible.
 \describe{
 \item{\code{task_id}}{Id of the task to cancel}
 
-\item{\code{wait}}{Wait for the task to be stopped, if it was running. If
-\code{delete} is \code{TRUE}, then we will always wait for the task to stop.}
+\item{\code{wait}}{Wait for the task to be stopped, if it was running.}
 
-\item{\code{delete}}{Delete the task after cancelling (if cancelling
-was successful).}
+\item{\code{timeout_wait}}{Maximum time, in seconds, to wait for the task
+to be cancelled by the worker.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/rrq_expect_worker.Rd
+++ b/man/rrq_expect_worker.Rd
@@ -4,12 +4,12 @@
 \alias{rrq_expect_worker}
 \title{Register expected workers}
 \usage{
-rrq_expect_worker(obj, names)
+rrq_expect_worker(obj, ids)
 }
 \arguments{
 \item{obj}{A rrq_controller object}
 
-\item{names}{Names of expected workers}
+\item{ids}{Ids of expected workers}
 }
 \description{
 Register that workers are expected.  This generates a key that one

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -15,7 +15,7 @@ but will sit and poll a queue for jobs.
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{name}}{The name of the worker}
+\item{\code{id}}{The id of the worker}
 }
 \if{html}{\out{</div>}}
 }
@@ -46,7 +46,7 @@ Constructor
   queue_id,
   con = redux::hiredis(),
   key_alive = NULL,
-  worker_name = NULL,
+  worker_id = NULL,
   queue = NULL,
   time_poll = NULL,
   timeout_idle = NULL,
@@ -69,8 +69,8 @@ prefix to all the keys in the redis database}
 \item{\code{key_alive}}{Optional key that will be written once the
 worker is alive.}
 
-\item{\code{worker_name}}{Optional worker name.  If omitted, a random
-name will be created.}
+\item{\code{worker_id}}{Optional worker id.  If omitted, a random
+id will be created.}
 
 \item{\code{queue}}{Queues to listen on, listed in decreasing order of
 priority. If not given, we listen on the "default" queue.}

--- a/man/rrq_worker_from_config.Rd
+++ b/man/rrq_worker_from_config.Rd
@@ -7,7 +7,7 @@
 rrq_worker_from_config(
   queue_id,
   worker_config = "localhost",
-  worker_name = NULL,
+  worker_id = NULL,
   key_alive = NULL,
   con = redux::hiredis(),
   timeout = 5
@@ -19,8 +19,8 @@ rrq_worker_from_config(
 \item{worker_config}{Optional name of the configuration. The
 default "localhost" configuration always exists.}
 
-\item{worker_name}{The name of the worker (if not given a random
-name is used)}
+\item{worker_id}{The id of the worker (if not given a random
+id is used)}
 
 \item{key_alive}{Optional key to write to, indicating that the
 worker is alive. This can be passed to

--- a/man/rrq_worker_script.Rd
+++ b/man/rrq_worker_script.Rd
@@ -48,7 +48,7 @@ The helper script supports the same arguments as
 \itemize{
 \item \code{queue_id} as the sole positional argument
 \item \code{worker_config} as \code{--config}
-\item \code{worker_name} as \code{--name}
+\item \code{worker_id} as \code{--worker-id}
 \item \code{key_alive} as \code{--key-alive}
 }
 
@@ -58,7 +58,7 @@ environment variable (see \code{\link[redux:hiredis]{redux::hiredis()}} for deta
 For example to create a worker \code{myworker} with configuration
 \code{myconfig} on queue \code{myqueue} you might use
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{./rrq_worker --config=myconfig --name=myworker myqueue
+\if{html}{\out{<div class="sourceCode">}}\preformatted{./rrq_worker --config=myconfig --worker-id=myworker myqueue
 }\if{html}{\out{</div>}}
 }
 \examples{

--- a/man/rrq_worker_spawn.Rd
+++ b/man/rrq_worker_spawn.Rd
@@ -11,7 +11,7 @@ rrq_worker_spawn(
   logdir = NULL,
   timeout = 600,
   worker_config = "localhost",
-  worker_name_base = NULL,
+  worker_id_base = NULL,
   time_poll = 1,
   progress = NULL
 )
@@ -31,8 +31,9 @@ log to, interpreted relative to the current working directory}
 \item{worker_config}{Name of the configuration to use.  By default
 the \code{"localhost"} configuration is used}
 
-\item{worker_name_base}{Optional base to construct the worker
-names from.  If omitted a random name will be used.}
+\item{worker_id_base}{Optional base to construct the worker ids
+from.  If omitted a random base will be used. Actual ids will be
+created but appending integers to this base.}
 
 \item{time_poll}{Polling period (in seconds) while waiting for
 workers to come up.  Must be an integer, at least 1.}

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -18,7 +18,7 @@ test_that("lapply simple case", {
   expect_equal(obj$task_status(grp$task_ids),
                set_names(rep(TASK_MISSING, 10), grp$task_ids))
 
-  log <- obj$worker_log_tail(w$name, Inf)
+  log <- obj$worker_log_tail(w$id, Inf)
   expect_equal(log$command,
                c("ALIVE", "ENVIR", "ENVIR", "QUEUE",
                  rep(c("TASK_START", "TASK_COMPLETE"), 10),

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -2,7 +2,7 @@ test_that("clean up exited workers", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
 
-  expect_equal(obj$worker_list(), w$name)
+  expect_equal(obj$worker_list(), w$id)
 
   id <- obj$message_send("STOP")
 
@@ -12,18 +12,18 @@ test_that("clean up exited workers", {
   w$shutdown()
 
   expect_equal(
-    obj$message_get_response(id, w$name),
-    set_names(list("BYE"), w$name))
+    obj$message_get_response(id, w$id),
+    set_names(list("BYE"), w$id))
 
-  log <- obj$worker_log_tail(w$name, n = Inf)
+  log <- obj$worker_log_tail(w$id, n = Inf)
   expect_equal(log$command, c("ALIVE", "ENVIR", "ENVIR", "QUEUE",
                               "MESSAGE", "RESPONSE", "STOP"))
 
-  expect_equal(obj$worker_list_exited(), w$name)
-  expect_equal(obj$worker_delete_exited(), w$name)
+  expect_equal(obj$worker_list_exited(), w$id)
+  expect_equal(obj$worker_delete_exited(), w$id)
   expect_equal(obj$worker_list_exited(), character(0))
   expect_equal(obj$worker_delete_exited(), character(0))
-  expect_error(obj$worker_delete_exited(w$name),
+  expect_error(obj$worker_delete_exited(w$id),
                "Workers .+ may not have exited or may not exist")
 })
 
@@ -69,11 +69,11 @@ test_that("worker catch graceful stop", {
   worker_catch_stop(w, r6_private(w))(rrq_worker_stop(w, "message"))
 
   expect_false(r6_private(w)$loop_continue)
-  log <- obj$worker_log_tail(w$name)
+  log <- obj$worker_log_tail(w$id)
   expect_equal(log$command, "STOP")
   expect_equal(log$message, "OK (message)")
   expect_equal(obj$worker_list(), character(0))
-  expect_equal(obj$worker_list_exited(), w$name)
+  expect_equal(obj$worker_list_exited(), w$id)
 })
 
 
@@ -91,21 +91,21 @@ test_that("worker catch naked error", {
                all = FALSE)
 
   expect_false(r6_private(w)$loop_continue)
-  log <- obj$worker_log_tail(w$name)
+  log <- obj$worker_log_tail(w$id)
   expect_equal(log$command, "STOP")
   expect_equal(log$message, "ERROR")
   expect_equal(obj$worker_list(), character(0))
-  expect_equal(obj$worker_list_exited(), w$name)
+  expect_equal(obj$worker_list_exited(), w$id)
 })
 
 
-test_that("worker names can't be duplicated", {
+test_that("worker ids can't be duplicated", {
   obj <- test_rrq()
-  name <- ids::random_id()
-  w <- test_worker_blocking(obj, worker_name = name)
-  expect_equal(w$name, name)
+  id <- ids::random_id()
+  w <- test_worker_blocking(obj, worker_id = id)
+  expect_equal(w$id, id)
   expect_error(
-    test_worker_blocking(obj, worker_name = name),
+    test_worker_blocking(obj, worker_id = id),
     "Looks like this worker exists already...",
     fixed = TRUE)
 })
@@ -113,10 +113,10 @@ test_that("worker names can't be duplicated", {
 
 test_that("Child workers require a parent", {
   con <- test_hiredis()
-  name <- ids::random_id()
+  id <- ids::random_id()
   queue_id <- test_name(NULL)
   expect_error(
-    rrq_worker$new(queue_id, con, worker_name = name, is_child = TRUE),
+    rrq_worker$new(queue_id, con, worker_id = id, is_child = TRUE),
     "Can't be a child of nonexistant worker")
 })
 
@@ -181,11 +181,11 @@ test_that("Can't kill non-local workers", {
   obj <- test_rrq()
   w <- test_worker_blocking(obj)
 
-  info <- obj$worker_info(w$name)[[w$name]]
+  info <- obj$worker_info(w$id)[[w$id]]
   info$hostname <- paste0(info$hostname, "_but_on_mars")
-  obj$con$HSET(queue_keys(obj)$worker_info, w$name, object_to_bin(info))
+  obj$con$HSET(queue_keys(obj)$worker_info, w$id, object_to_bin(info))
   expect_error(
-    obj$worker_stop(w$name, "kill_local"),
+    obj$worker_stop(w$id, "kill_local"),
     "Not all workers are local:")
 })
 
@@ -195,28 +195,28 @@ test_that("rrq_worker_main_args parse", {
     rrq_worker_main_args("name"),
     list(queue_id = "name",
          config = "localhost",
-         name = NULL,
+         id = NULL,
          key_alive = NULL))
 
   expect_equal(
-    rrq_worker_main_args(c("name", "--name=bob")),
+    rrq_worker_main_args(c("name", "--id=bob")),
     list(queue_id = "name",
          config = "localhost",
-         name = "bob",
+         id = "bob",
          key_alive = NULL))
 
   expect_equal(
     rrq_worker_main_args(c("name", "--key-alive=key")),
     list(queue_id = "name",
          config = "localhost",
-         name = NULL,
+         id = NULL,
          key_alive = "key"))
 
   expect_equal(
     rrq_worker_main_args(c("name", "--config=config")),
     list(queue_id = "name",
          config = "config",
-         name = NULL,
+         id = NULL,
          key_alive = NULL))
 })
 
@@ -226,7 +226,7 @@ test_that("can pass --key-alive", {
     rrq_worker_main_args(c("name", "--key-alive=key")),
     list(queue_id = "name",
          config = "localhost",
-         name = NULL,
+         id = NULL,
          key_alive = "key"))
 })
 
@@ -265,9 +265,9 @@ test_that("clean up worker when one still running", {
   w1 <- test_worker_blocking(obj)
   w2 <- test_worker_blocking(obj)
 
-  expect_setequal(obj$worker_list(), c(w1$name, w2$name))
+  expect_setequal(obj$worker_list(), c(w1$id, w2$id))
 
-  id <- obj$message_send("STOP", worker_ids = w1$name)
+  id <- obj$message_send("STOP", worker_ids = w1$id)
 
   expect_error(
     w1$step(), "BYE", class = "rrq_worker_stop")
@@ -276,13 +276,13 @@ test_that("clean up worker when one still running", {
   w1$shutdown()
 
   expect_equal(
-    obj$message_get_response(id, w1$name),
-    set_names(list("BYE"), w1$name))
+    obj$message_get_response(id, w1$id),
+    set_names(list("BYE"), w1$id))
 
-  expect_equal(obj$worker_list_exited(), w1$name)
+  expect_equal(obj$worker_list_exited(), w1$id)
 
-  expect_equal(obj$worker_delete_exited(), w1$name)
-  expect_setequal(obj$worker_list(), w2$name)
+  expect_equal(obj$worker_delete_exited(), w1$id)
+  expect_setequal(obj$worker_list(), w2$id)
   expect_equal(obj$worker_list_exited(), character(0))
   expect_equal(obj$worker_delete_exited(), character(0))
 })

--- a/tests/testthat/test-rrq-workers.R
+++ b/tests/testthat/test-rrq-workers.R
@@ -195,28 +195,28 @@ test_that("rrq_worker_main_args parse", {
     rrq_worker_main_args("name"),
     list(queue_id = "name",
          config = "localhost",
-         id = NULL,
+         worker_id = NULL,
          key_alive = NULL))
 
   expect_equal(
-    rrq_worker_main_args(c("name", "--id=bob")),
+    rrq_worker_main_args(c("name", "--worker-id=bob")),
     list(queue_id = "name",
          config = "localhost",
-         id = "bob",
+         worker_id = "bob",
          key_alive = NULL))
 
   expect_equal(
     rrq_worker_main_args(c("name", "--key-alive=key")),
     list(queue_id = "name",
          config = "localhost",
-         id = NULL,
+         worker_id = NULL,
          key_alive = "key"))
 
   expect_equal(
     rrq_worker_main_args(c("name", "--config=config")),
     list(queue_id = "name",
          config = "config",
-         id = NULL,
+         worker_id = NULL,
          key_alive = NULL))
 })
 
@@ -226,7 +226,7 @@ test_that("can pass --key-alive", {
     rrq_worker_main_args(c("name", "--key-alive=key")),
     list(queue_id = "name",
          config = "localhost",
-         id = NULL,
+         worker_id = NULL,
          key_alive = "key"))
 })
 

--- a/tests/testthat/test-worker-config.R
+++ b/tests/testthat/test-worker-config.R
@@ -92,7 +92,7 @@ test_that("worker timeout", {
 
   id <- obj$message_send("TIMEOUT_GET")
   w$step(TRUE)
-  res <- obj$message_get_response(id, w$name)[[1]]
+  res <- obj$message_get_response(id, w$id)[[1]]
   expect_equal(res[["timeout_idle"]], t)
   expect_lte(res[["remaining"]], t)
 })
@@ -108,7 +108,7 @@ test_that("infinite timeout", {
 
   id <- obj$message_send("TIMEOUT_GET")
   w$step(TRUE)
-  res <- obj$message_get_response(id, w$name)[[1]]
+  res <- obj$message_get_response(id, w$id)[[1]]
   expect_equal(res, c(timeout_idle = Inf, remaining = Inf))
 })
 

--- a/tests/testthat/test-worker-spawn.R
+++ b/tests/testthat/test-worker-spawn.R
@@ -1,15 +1,15 @@
 test_that("Don't wait", {
   obj <- test_rrq()
   res <- test_worker_spawn(obj, 4, timeout = 0)
-  expect_type(res$names, "character")
-  expect_match(res$names, "_[0-9]+$")
+  expect_type(res$ids, "character")
+  expect_match(res$ids, "_[0-9]+$")
   expect_type(res$key_alive, "character")
 
   ans <- rrq_worker_wait(obj, res$key_alive, timeout = 10, time_poll = 1)
-  expect_setequal(ans, res$names)
+  expect_setequal(ans, res$ids)
 
   ans <- rrq_worker_wait(obj, res$key_alive, timeout = 10, time_poll = 1)
-  expect_equal(ans, res$names)
+  expect_equal(ans, res$ids)
 })
 
 

--- a/tests/testthat/test-zzz-fault-tolerance.R
+++ b/tests/testthat/test-zzz-fault-tolerance.R
@@ -9,7 +9,7 @@ test_that("heartbeat", {
   w <- test_worker_blocking(obj)
   dat <- w$info()
   expect_equal(dat$heartbeat_key,
-               rrq_key_worker_heartbeat(obj$queue_id, w$name))
+               rrq_key_worker_heartbeat(obj$queue_id, w$id))
 
   expect_equal(obj$con$EXISTS(dat$heartbeat_key), 1)
   expect_lte(obj$con$PTTL(dat$heartbeat_key),


### PR DESCRIPTION
I am not sure why we had worker name as a special thing but we're inconsistent everywhere. This uses `id` instead and is very churny as a result.