### PR TITLE
Tidy up worker run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.6.19
+Version: 0.6.20
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/worker.R
+++ b/R/worker.R
@@ -256,7 +256,7 @@ rrq_worker <- R6::R6Class(
     ##'   an `rrq` job, or to `TRUE` if you want to be sure that
     ##'   progress messages have made it to the server.
     progress = function(value, error = TRUE) {
-      task_id <- private$active_task$task_id
+      task_id <- private$active_task_id
       if (is.null(task_id)) {
         if (error) {
           stop("rrq_task_progress_update called with no active task")
@@ -277,7 +277,7 @@ rrq_worker <- R6::R6Class(
       cache$active_worker <- self
       on.exit(cache$active_worker <- NULL)
       task <- bin_to_object(private$con$HGET(private$keys$task_expr, task_id))
-      private$active_task <- list(task_id = task_id)
+      private$active_task_id <- task_id
       worker_run_task_local(task, self, private)
     },
 
@@ -302,7 +302,7 @@ rrq_worker <- R6::R6Class(
   ),
 
   private = list(
-    active_task = NULL,
+    active_task_id = NULL,
     envir = NULL,
     loop_continue = FALSE,
     paused = FALSE,

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -120,14 +120,14 @@ worker_run_task_start <- function(worker, private, task_id) {
   worker_id <- worker$id
   dat <- private$con$pipeline(
     worker_log(redis, keys, "TASK_START", task_id,
-               private$is_child, private$verbose),            # 1
-    redis$HSET(keys$worker_status,   worker_id, WORKER_BUSY), # 2
-    redis$HSET(keys$worker_task,     worker_id, task_id),     # 3
-    redis$HSET(keys$task_worker,     task_id,   worker_id),   # 4
-    redis$HSET(keys$task_status,     task_id,   TASK_RUNNING),# 5
-    redis$HSET(keys$task_time_start, task_id,   timestamp()), # 6
-    redis$HGET(keys$task_local,      task_id),                # 7
-    redis$HGET(keys$task_expr,       task_id))                # 8
+               private$is_child, private$verbose),             # 1
+    redis$HSET(keys$worker_status,   worker_id, WORKER_BUSY),  # 2
+    redis$HSET(keys$worker_task,     worker_id, task_id),      # 3
+    redis$HSET(keys$task_worker,     task_id,   worker_id),    # 4
+    redis$HSET(keys$task_status,     task_id,   TASK_RUNNING), # 5
+    redis$HSET(keys$task_time_start, task_id,   timestamp()),  # 6
+    redis$HGET(keys$task_local,      task_id),                 # 7
+    redis$HGET(keys$task_expr,       task_id))                 # 8
 
   if (is_task_redirect(dat[[8]])) {
     task_id_root <- dat[[8]]

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -22,7 +22,7 @@ worker_run_task <- function(worker, private, task_id) {
     worker_log(redis, keys, paste0("TASK_", status), task_id,
                private$is_child, private$verbose))
 
-  private$active_task <- NULL
+  private$active_task_id <- NULL
   invisible()
 }
 
@@ -120,34 +120,29 @@ worker_run_task_start <- function(worker, private, task_id) {
   worker_id <- worker$id
   dat <- private$con$pipeline(
     worker_log(redis, keys, "TASK_START", task_id,
-               private$is_child, private$verbose),
-    redis$HSET(keys$worker_status,   worker_id, WORKER_BUSY),
-    redis$HSET(keys$worker_task,     worker_id, task_id),
-    redis$HSET(keys$task_worker,     task_id,   worker_id),
-    redis$HSET(keys$task_status,     task_id,   TASK_RUNNING),
-    redis$HSET(keys$task_time_start, task_id,   timestamp()),
-    redis$HGET(keys$task_complete,   task_id),
-    redis$HGET(keys$task_local,      task_id),
-    redis$HGET(keys$task_expr,       task_id),
-    redis$HGET(keys$task_cancel,     task_id))
+               private$is_child, private$verbose),            # 1
+    redis$HSET(keys$worker_status,   worker_id, WORKER_BUSY), # 2
+    redis$HSET(keys$worker_task,     worker_id, task_id),     # 3
+    redis$HSET(keys$task_worker,     task_id,   worker_id),   # 4
+    redis$HSET(keys$task_status,     task_id,   TASK_RUNNING),# 5
+    redis$HSET(keys$task_time_start, task_id,   timestamp()), # 6
+    redis$HGET(keys$task_local,      task_id),                # 7
+    redis$HGET(keys$task_expr,       task_id))                # 8
 
-  if (is_task_redirect(dat[[9]])) {
-    task_id_root <- dat[[9]]
-    dat[7:9] <-
-      private$con$pipeline(
-        redis$HGET(keys$task_complete, task_id_root),
-        redis$HGET(keys$task_local,    task_id_root),
-        redis$HGET(keys$task_expr,     task_id_root))
+  if (is_task_redirect(dat[[8]])) {
+    task_id_root <- dat[[8]]
+    dat[7:8] <- private$con$pipeline(
+      redis$HGET(keys$task_local,    task_id_root),
+      redis$HGET(keys$task_expr,     task_id_root))
   }
 
-  ## This holds the bits of worker state we might need to refer to
-  ## later for a running task:
-  private$active_task <- list(task_id = task_id, key_complete = dat[[7]])
+  ## This might be used later for recording task progress
+  private$active_task_id <- task_id
 
   ## And this holds the data used in worker_run_task_to actually run
   ## the task
-  ret <- bin_to_object(dat[[9]])
-  ret$separate_process <- dat[[8]] == "FALSE" # NOTE: not a coersion
+  ret <- bin_to_object(dat[[8]])
+  ret$separate_process <- dat[[7]] == "FALSE" # NOTE: not a coersion
   ret$id <- task_id
   ret
 }


### PR DESCRIPTION
Things I noticed elsewhere but didn't want to put into other PRs, as we never use either the cancel key or the key_complete as pulled here. I've tidied up the "active task" to be just the task id, too.