### PR TITLE
Fix environment bug in bulk submission

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.7.0
+Version: 0.7.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/expression.R
+++ b/R/expression.R
@@ -130,5 +130,10 @@ expression_restore_locals <- function(dat, parent, store) {
   if (length(objects) > 0L) {
     list2env(set_names(store$mget(objects), names(objects)), e)
   }
+  reset_environment <- !is.null(dat$function_hash) &&
+    identical(environment(e[[dat$function_hash]]), .GlobalEnv)
+  if (reset_environment) {
+    environment(e[[dat$function_hash]]) <- e
+  }
   e
 }

--- a/tests/testthat/funs-bulk.R
+++ b/tests/testthat/funs-bulk.R
@@ -1,0 +1,4 @@
+a <- 10
+f <- function(x) {
+  a + x
+}

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -349,3 +349,31 @@ test_that("Set completion keys", {
                       function(k) list_to_character(obj$con$LRANGE(k, 0, -1))),
                as.list(grp$task_ids))
 })
+
+
+test_that("allow referring to locals in bulk", {
+  obj <- test_rrq("funs-bulk.R")
+  obj$envir(rrq::rrq_envir(sources = c("funs-bulk.R")))
+
+  ## We can't easily the previous error with a blocking worker because:
+  ##
+  ## * if sourcing functions into an environment we *do* capture the
+  ##   enclosing environment and the underlying variable so the
+  ##   restored functions are just fine
+  ## * if sourcing into the global environment, then the worker can
+  ##   see everything and the restored function works fine.
+  ##
+  ## However, if we delete the objects from the global environment
+  ## just before running we get it to fail nicely:
+  env <- globalenv()
+  sys.source("funs-bulk.R", env)
+  g <- obj$lapply(1, f, timeout_task_wait = 0, envir = env)
+  rm("f", "a", envir = env)
+
+  w <- test_worker_blocking(obj)
+  w$step(TRUE)
+
+  id <- g$task_ids
+  expect_equal(unname(obj$task_status(id)), TASK_COMPLETE)
+  expect_equal(obj$task_result(id), 11)
+})

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -355,7 +355,8 @@ test_that("allow referring to locals in bulk", {
   obj <- test_rrq("funs-bulk.R")
   obj$envir(rrq::rrq_envir(sources = c("funs-bulk.R")))
 
-  ## We can't easily the previous error with a blocking worker because:
+  ## We can't easily recreate the previous error (#98, #99) with a
+  ## blocking worker because:
   ##
   ## * if sourcing functions into an environment we *do* capture the
   ##   enclosing environment and the underlying variable so the

--- a/tests/testthat/test-expression.R
+++ b/tests/testthat/test-expression.R
@@ -139,7 +139,8 @@ test_that("can store special function values", {
   res <- expression_prepare(quote(.(a, b)), e, store, tag,
                             function_value = f)
   expect_match(res$function_hash, "^[[:xdigit:]]+$")
-  e2 <- expression_restore_locals(res, emptyenv(), store)
+  env <- new.env(parent = baseenv())
+  e2 <- expression_restore_locals(res, env, store)
   expect_equal(sort(names(e2)), sort(c("a", "b", res$function_hash)))
   expect_equal(e2[[res$function_hash]](1, 2), 3)
   expect_equal(e2$a, 1)
@@ -158,7 +159,8 @@ test_that("can restore function even with no variables", {
   res <- expression_prepare(quote(.(1, 2)), e, store, tag,
                             function_value = f)
   expect_match(res$function_hash, "^[[:xdigit:]]+$")
-  e2 <- expression_restore_locals(res, emptyenv(), store)
+  env <- new.env(parent = baseenv())
+  e2 <- expression_restore_locals(res, env, store)
   expect_equal(names(e2), res$function_hash)
   expect_equal(e2[[res$function_hash]](1, 2), 3)
   expect_equal(deparse(res$expr[[1]]), res$function_hash)


### PR DESCRIPTION
The issue here is sort of described in the issue (#98) and in the test case. Basically, in the most common real-world situation (functions sourced globally) any function we use via lapply or enqueue bulk ends up with an environment that means that it cannot find any values referred to using lexical scope! I think that callr does this nicely by passing in the `package` environment, it's a hard problem really.

Here, we just fix up the environments of any functions that come through anonymously.

Fixes #98