### PR TITLE
Fix lints with newer lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,5 @@
 linters: linters_with_defaults(
+    indentation_linter = NULL,
     object_length_linter = NULL,
     object_usage_linter = NULL,
     cyclocomp_linter = NULL

--- a/tests/testthat/myfuns.R
+++ b/tests/testthat/myfuns.R
@@ -80,8 +80,9 @@ run_with_progress_signal <- function(n, wait) {
 
 
 dirty_double <- function(value) {
-  prev <- .GlobalEnv$.rrq_dirty_double
-  .GlobalEnv$.rrq_dirty_double <- value
+  env <- globalenv()
+  prev <- .env$.rrq_dirty_double
+  env$.rrq_dirty_double <- value
   list(prev, value * 2)
 }
 

--- a/tests/testthat/myfuns.R
+++ b/tests/testthat/myfuns.R
@@ -81,7 +81,7 @@ run_with_progress_signal <- function(n, wait) {
 
 dirty_double <- function(value) {
   env <- globalenv()
-  prev <- .env$.rrq_dirty_double
+  prev <- env$.rrq_dirty_double
   env$.rrq_dirty_double <- value
   list(prev, value * 2)
 }


### PR DESCRIPTION
There's a new lintr version, and it has a well-meaning but (IMO) poorly implemented indentation linter. It might get there in the end, but needs disabling here or just adds noise