### PR TITLE
Allow not naming return values from most functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.7.8
+Version: 0.7.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/rrq_controller.R
+++ b/R/rrq_controller.R
@@ -694,7 +694,8 @@ rrq_controller <- R6::R6Class(
     ##'   rrq controller
     ##' @param task_ids Character vector of task ids to check for existence.
     task_exists = function(task_ids) {
-      rrq_task_exists(task_ids, self)
+      named <- TRUE
+      rrq_task_exists(task_ids, named, self)
     },
 
     ##' @description Return a character vector of task statuses. The name
@@ -705,7 +706,8 @@ rrq_controller <- R6::R6Class(
     ##' would like statuses. If not given (or `NULL`) then the status of
     ##' all task ids known to this rrq controller is returned.
     task_status = function(task_ids = NULL, follow = NULL) {
-      rrq_task_status(task_ids, follow, self)
+      named <- TRUE
+      rrq_task_status(task_ids %||% self$task_list(), named, follow, self)
     },
 
     ##' @description Retrieve task progress, if set. This will be `NULL`
@@ -783,7 +785,8 @@ rrq_controller <- R6::R6Class(
     ##' @param error Logical, indicating if we should throw an error if
     ##'   the task was not successful. See `$task_result()` for details.
     tasks_result = function(task_ids, error = FALSE, follow = NULL) {
-      rrq_task_results(task_ids, error, follow, self)
+      named <- TRUE
+      rrq_task_results(task_ids, error, named, follow, self)
     },
 
     ##' @description Poll for a task to complete, returning the result
@@ -1404,7 +1407,8 @@ rrq_object_store <- function(con, keys) {
 
 verify_dependencies_exist <- function(controller, depends_on) {
   if (!is.null(depends_on)) {
-    dependencies_exist <- rrq_task_exists(depends_on, controller = controller)
+    dependencies_exist <- rrq_task_exists(depends_on, named = TRUE,
+                                          controller = controller)
     if (!all(dependencies_exist)) {
       missing <- names(dependencies_exist[!dependencies_exist])
       error_msg <- ngettext(

--- a/R/time.R
+++ b/R/time.R
@@ -69,7 +69,10 @@ wait_status_change <- function(controller, task_id, status,
                                timeout = 2, time_poll = 0.05) {
   remaining <- time_checker(timeout)
   while (remaining() > 0) {
-    if (all(rrq_task_status(task_id, FALSE, controller) != status)) {
+    done <- rrq_task_status(task_id,
+                            follow = FALSE,
+                            controller = controller) != status
+    if (all(done)) {
       return()
     }
     Sys.sleep(time_poll)

--- a/man/rrq_task_exists.Rd
+++ b/man/rrq_task_exists.Rd
@@ -4,10 +4,14 @@
 \alias{rrq_task_exists}
 \title{Test if tasks exist}
 \usage{
-rrq_task_exists(task_ids, controller = NULL)
+rrq_task_exists(task_ids, named = FALSE, controller = NULL)
 }
 \arguments{
 \item{task_ids}{Vector of task ids to check}
+
+\item{named}{Logical, indicating if the return value should be
+named with the task ids; as these are quite long this can make
+the value a little awkward to work with.}
 
 \item{controller}{The controller to use.  If not given (or \code{NULL})
 we'll use the controller registered with

--- a/man/rrq_task_results.Rd
+++ b/man/rrq_task_results.Rd
@@ -5,7 +5,13 @@
 \title{Get the results of a group of tasks, returning them as a list.
 See \link{rrq_task_result} for getting the result of a single task.}
 \usage{
-rrq_task_results(task_ids, error = FALSE, follow = NULL, controller = NULL)
+rrq_task_results(
+  task_ids,
+  error = FALSE,
+  named = FALSE,
+  follow = NULL,
+  controller = NULL
+)
 }
 \arguments{
 \item{task_ids}{A vector of task ids for which the task result
@@ -13,6 +19,10 @@ is wanted.}
 
 \item{error}{Logical, indicating if we should throw an error if
 the task was not successful. See \code{\link[=rrq_task_result]{rrq_task_result()}} for details.}
+
+\item{named}{Logical, indicating if the return value should be
+named with the task ids; as these are quite long this can make
+the value a little awkward to work with.}
 
 \item{follow}{Optional logical, indicating if we should follow any
 redirects set up by doing \link{rrq_task_retry}. If not given, falls

--- a/man/rrq_task_status.Rd
+++ b/man/rrq_task_status.Rd
@@ -4,11 +4,15 @@
 \alias{rrq_task_status}
 \title{Fetch task statuses}
 \usage{
-rrq_task_status(task_ids, follow = NULL, controller = NULL)
+rrq_task_status(task_ids, named = FALSE, follow = NULL, controller = NULL)
 }
 \arguments{
 \item{task_ids}{Optional character vector of task ids for which you
 would like statuses.}
+
+\item{named}{Logical, indicating if the return value should be
+named with the task ids; as these are quite long this can make
+the value a little awkward to work with.}
 
 \item{follow}{Optional logical, indicating if we should follow any
 redirects set up by doing \link{rrq_task_retry}. If not given, falls

--- a/tests/testthat/test-rrq-task.R
+++ b/tests/testthat/test-rrq-task.R
@@ -114,3 +114,49 @@ test_that("can wait for tasks", {
     mockery::mock_args(mock_pipeline)[[5]],
     list(redis$BLPOP(key_complete[1], 1), redis$HMGET(key_status, t[1])))
 })
+
+
+test_that("can optionally name status elements", {
+  obj <- test_rrq()
+  t <- rrq_task_create_expr(sqrt(2), controller = obj)
+  expect_equal(
+    rrq_task_status(t, controller = obj), TASK_PENDING)
+  expect_equal(
+    rrq_task_status(t, named = TRUE, controller = obj),
+    set_names(TASK_PENDING, t))
+})
+
+
+test_that("can get status of no tasks", {
+  obj <- test_rrq()
+  expect_equal(rrq_task_status(character(), controller = obj),
+               character())
+  expect_equal(rrq_task_status(character(), named = TRUE, controller = obj),
+               set_names(character(), character()))
+})
+
+
+test_that("can test existance of no tasks", {
+  obj <- test_rrq()
+  expect_equal(rrq_task_exists(character(), controller = obj),
+               logical())
+  expect_equal(rrq_task_exists(character(), named = TRUE, controller = obj),
+               set_names(logical(), character()))
+})
+
+
+test_that("can get times of no tasks", {
+  obj <- test_rrq()
+  expect_equal(rrq_task_times(character(), controller = obj),
+               matrix(numeric(), 0, 4, FALSE,
+                      list(NULL, c("submit", "start", "complete", "moved"))))
+})
+
+
+test_that("Can get results from no tasks", {
+  obj <- test_rrq()
+  expect_equal(rrq_task_results(character(), controller = obj),
+               list())
+  expect_equal(rrq_task_results(character(), named = TRUE, controller = obj),
+               set_names(list(), character()))
+})

--- a/tests/testthat/test-rrq-task.R
+++ b/tests/testthat/test-rrq-task.R
@@ -160,3 +160,22 @@ test_that("Can get results from no tasks", {
   expect_equal(rrq_task_results(character(), named = TRUE, controller = obj),
                set_names(list(), character()))
 })
+
+
+test_that("overview can filter by tasks", {
+  obj <- test_rrq()
+  id <- rrq::rrq_task_create_bulk_call(sqrt, 1:10, controller = obj)
+  empty <- rrq_task_overview(character(), controller = obj)
+  expect_equal(
+    empty,
+    set_names(as.list(rep(0, length(TASK$all))), TASK$all))
+  expect_equal(
+    rrq_task_overview(controller = obj),
+    modifyList(empty, list(PENDING = 10)))
+  expect_equal(
+    rrq_task_overview(NULL, controller = obj),
+    modifyList(empty, list(PENDING = 10)))
+  expect_equal(
+    rrq_task_overview(id[1:3], controller = obj),
+    modifyList(empty, list(PENDING = 3)))
+})

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -548,21 +548,23 @@ test_that("queueing with depends_on errored task fails", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)
 
-  t <- obj$enqueue(only_positive(-1))
+  t1 <- obj$enqueue(only_positive(-1))
   w$step(TRUE)
-  res <- obj$task_result(t)
+  res <- obj$task_result(t1)
   expect_s3_class(res, "rrq_task_error")
 
-  expect_error(obj$enqueue(sin(0), depends_on = t),
+  expect_error(obj$enqueue(sin(0), depends_on = t1),
                paste0("Failed to queue as dependent tasks failed:\n",
-                      t, ": ERROR"),
+                      t1, ": ERROR"),
                fixed = TRUE)
 
+  ids <- obj$task_list()
+  expect_length(ids, 2)
+  t2 <- setdiff(ids, t1)
+
   ## Task is set to impossible
-  status <- obj$task_status()
-  expect_length(status, 2)
-  expect_true(TASK_IMPOSSIBLE %in% status)
-  expect_true(TASK_ERROR %in% status)
+  expect_equal(obj$task_status(t1), set_names(TASK_ERROR, t1))
+  expect_equal(obj$task_status(t2), set_names(TASK_IMPOSSIBLE, t2))
 })
 
 


### PR DESCRIPTION
Small one; just allows return types not to be named, which is consistent with hipercow.  This will makes the docs a bit easier to write.  I've left the behaviour unchanged for the legacy controller.