### PR TITLE
Add basic env variables to every worker

### DIFF
--- a/R/worker.R
+++ b/R/worker.R
@@ -87,6 +87,13 @@ rrq_worker <- R6::R6Class(
           worker_initialise(self, private, config),
           error = worker_catch_error(self, private))
       }
+
+      if (is.null(private$envir)) {
+        private$envir <- new.env(parent = .GlobalEnv)
+      }
+      private$envir$WORKER_ID <- self$id
+      private$envir$WORKER_CONFIG <- self$config
+      private$envir$WORKER_CONTROLLER <- self$controller
     },
 
     ##' @description Return information about this worker, a list of
@@ -110,16 +117,9 @@ rrq_worker <- R6::R6Class(
     ##' @description Load the worker environment by creating a new
     ##'   environment object and running the create hook (if configured).
     ##'   See [rrq::rrq_worker_envir_set()] for details.
-    ##'   Some environment variables are created by default:
-    ##'     * `WORKER_ID` - same as `id` field
-    ##'     * `WORKER_CONFIG` - same as `config` field
-    ##'     * `WORKER_CONTROLLER` - same as `controller` field
     load_envir = function() {
       self$log("ENVIR", "new")
       private$envir <- new.env(parent = .GlobalEnv)
-      private$envir$WORKER_ID <- self$id
-      private$envir$WORKER_CONFIG <- self$config
-      private$envir$WORKER_CONTROLLER <- self$controller
       create <- self$controller$con$GET(self$controller$keys$envir)
       if (!is.null(create)) {
         self$log("ENVIR", "create")

--- a/R/worker.R
+++ b/R/worker.R
@@ -110,6 +110,10 @@ rrq_worker <- R6::R6Class(
     ##' @description Load the worker environment by creating a new
     ##'   environment object and running the create hook (if configured).
     ##'   See [rrq::rrq_worker_envir_set()] for details.
+    ##'   Some environment variables are created by default:
+    ##'     * `WORKER_ID` - same as `id` field
+    ##'     * `WORKER_CONFIG` - same as `config` field
+    ##'     * `WORKER_CONTROLLER` - same as `controller` field
     load_envir = function() {
       self$log("ENVIR", "new")
       private$envir <- new.env(parent = .GlobalEnv)

--- a/R/worker.R
+++ b/R/worker.R
@@ -203,8 +203,8 @@ rrq_worker <- R6::R6Class(
 
     ##' @description Evaluate a task. When running a task on a separate
     ##'   process, we will always set two environment variables:
-    ##'     * `WORKER_ID` this is the id field
-    ##'     * `TASK_ID` this is the task id
+    ##'     * `RRQ_WORKER_ID` this is the id field
+    ##'     * `RRQ_TASK_ID` this is the task id
     ##'
     ##' @param task_id A task identifier. It is undefined what happens if
     ##'   this identifier does not exist.

--- a/R/worker.R
+++ b/R/worker.R
@@ -201,7 +201,10 @@ rrq_worker <- R6::R6Class(
       invisible()
     },
 
-    ##' @description Evaluate a task
+    ##' @description Evaluate a task. When running a task on a separate
+    ##'   process, we will always set two environment variables:
+    ##'     * `WORKER_ID` this is the id field
+    ##'     * `TASK_ID` this is the task id
     ##'
     ##' @param task_id A task identifier. It is undefined what happens if
     ##'   this identifier does not exist.

--- a/R/worker.R
+++ b/R/worker.R
@@ -87,13 +87,6 @@ rrq_worker <- R6::R6Class(
           worker_initialise(self, private, config),
           error = worker_catch_error(self, private))
       }
-
-      if (is.null(private$envir)) {
-        private$envir <- new.env(parent = .GlobalEnv)
-      }
-      private$envir$WORKER_ID <- self$id
-      private$envir$WORKER_CONFIG <- self$config
-      private$envir$WORKER_CONTROLLER <- self$controller
     },
 
     ##' @description Return information about this worker, a list of

--- a/R/worker.R
+++ b/R/worker.R
@@ -113,6 +113,9 @@ rrq_worker <- R6::R6Class(
     load_envir = function() {
       self$log("ENVIR", "new")
       private$envir <- new.env(parent = .GlobalEnv)
+      private$envir$WORKER_ID <- self$id
+      private$envir$WORKER_CONFIG <- self$config
+      private$envir$WORKER_CONTROLLER <- self$controller
       create <- self$controller$con$GET(self$controller$keys$envir)
       if (!is.null(create)) {
         self$log("ENVIR", "create")

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -131,7 +131,9 @@ worker_run_task_separate_process <- function(task, worker, private) {
     list(redis_config, queue_id, worker_id, task_id),
     package = "rrq",
     supervise = TRUE,
-    env = c(callr::rcmd_safe_env(), WORKER_ID = worker_id))
+    env = c(callr::rcmd_safe_env(),
+            WORKER_ID = worker_id,
+            TASK_ID = task_id))
 
   con$HSET(keys$task_pid, task_id, px$get_pid())
 

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -58,8 +58,6 @@ worker_run_task_local_new <- function(task, worker, private) {
   keys <- worker$controller$keys
   store <- worker$controller$store
 
-  browser()
-
   top <- rlang::current_env() # not quite right, but better than nothing
   local <- new.env(parent = emptyenv())
   local$warnings <- collector(list())
@@ -132,7 +130,8 @@ worker_run_task_separate_process <- function(task, worker, private) {
     },
     list(redis_config, queue_id, worker_id, task_id),
     package = "rrq",
-    supervise = TRUE)
+    supervise = TRUE,
+    env = c(callr::rcmd_safe_env(), WORKER_ID = worker_id))
 
   con$HSET(keys$task_pid, task_id, px$get_pid())
 

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -132,8 +132,8 @@ worker_run_task_separate_process <- function(task, worker, private) {
     package = "rrq",
     supervise = TRUE,
     env = c(callr::rcmd_safe_env(),
-            WORKER_ID = worker_id,
-            TASK_ID = task_id))
+            RRQ_WORKER_ID = worker_id,
+            RRQ_TASK_ID = task_id))
 
   con$HSET(keys$task_pid, task_id, px$get_pid())
 

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -70,7 +70,7 @@ worker_run_task_local_new <- function(task, worker, private) {
       if (!is.null(task$variables)) {
         rlang::env_bind(envir, !!!task$variables)
       }
-      eval(task$expr, envir)
+      eval(task$expr, envir = envir)
     } else { # task$type is call
       fn <- task$fn
       args <- task$args
@@ -82,7 +82,7 @@ worker_run_task_local_new <- function(task, worker, private) {
       } else {
         call <- rlang::call2(fn$name, !!!args, .ns = fn$namespace)
       }
-      eval(call, envir)
+      eval(call, envir = envir)
     }
   },
   warning = function(e) {
@@ -122,7 +122,6 @@ worker_run_task_separate_process <- function(task, worker, private) {
   key_cancel <- keys$task_cancel
   poll_process <- private$poll_process
   timeout_process_die <- private$timeout_process_die
-  env <- private$envir
 
   worker$log("REMOTE", task_id)
   px <- callr::r_bg(
@@ -131,8 +130,7 @@ worker_run_task_separate_process <- function(task, worker, private) {
     },
     list(redis_config, queue_id, worker_id, task_id),
     package = "rrq",
-    supervise = TRUE,
-    env = env)
+    supervise = TRUE)
 
   con$HSET(keys$task_pid, task_id, px$get_pid())
 

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -58,6 +58,8 @@ worker_run_task_local_new <- function(task, worker, private) {
   keys <- worker$controller$keys
   store <- worker$controller$store
 
+  browser()
+
   top <- rlang::current_env() # not quite right, but better than nothing
   local <- new.env(parent = emptyenv())
   local$warnings <- collector(list())

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -70,7 +70,7 @@ worker_run_task_local_new <- function(task, worker, private) {
       if (!is.null(task$variables)) {
         rlang::env_bind(envir, !!!task$variables)
       }
-      eval(task$expr, envir = envir)
+      eval(task$expr, envir)
     } else { # task$type is call
       fn <- task$fn
       args <- task$args
@@ -82,7 +82,7 @@ worker_run_task_local_new <- function(task, worker, private) {
       } else {
         call <- rlang::call2(fn$name, !!!args, .ns = fn$namespace)
       }
-      eval(call, envir = envir)
+      eval(call, envir)
     }
   },
   warning = function(e) {

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -122,6 +122,7 @@ worker_run_task_separate_process <- function(task, worker, private) {
   key_cancel <- keys$task_cancel
   poll_process <- private$poll_process
   timeout_process_die <- private$timeout_process_die
+  env <- private$envir
 
   worker$log("REMOTE", task_id)
   px <- callr::r_bg(
@@ -130,7 +131,8 @@ worker_run_task_separate_process <- function(task, worker, private) {
     },
     list(redis_config, queue_id, worker_id, task_id),
     package = "rrq",
-    supervise = TRUE)
+    supervise = TRUE,
+    env = env)
 
   con$HSET(keys$task_pid, task_id, px$get_pid())
 

--- a/man/rrq_task_overview.Rd
+++ b/man/rrq_task_overview.Rd
@@ -7,9 +7,10 @@
 rrq_task_overview(task_ids = NULL, controller = NULL)
 }
 \arguments{
-\item{task_ids}{Optional character vector of task ids for which you
-would like the overview. If not given (or \code{NULL}) then the status of
-all task ids known to this rrq controller is used.}
+\item{task_ids}{Optional character vector of task ids for which
+you would like the overview. If not given (or \code{NULL}) then the
+status of all task ids known to this rrq controller is used
+(this might be fairly costly).}
 
 \item{controller}{The controller to use.  If not given (or \code{NULL})
 we'll use the controller registered with

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -125,6 +125,10 @@ format to screen and a machine-readable format to the redis database.
 Load the worker environment by creating a new
 environment object and running the create hook (if configured).
 See \code{\link[=rrq_worker_envir_set]{rrq_worker_envir_set()}} for details.
+Some environment variables are created by default:
+* \code{WORKER_ID} - same as \code{id} field
+* \code{WORKER_CONFIG} - same as \code{config} field
+* \code{WORKER_CONTROLLER} - same as \code{controller} field
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{rrq_worker$load_envir()}\if{html}{\out{</div>}}
 }

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -250,8 +250,8 @@ progress messages have made it to the server.}
 \subsection{Method \code{task_eval()}}{
 Evaluate a task. When running a task on a separate
 process, we will always set two environment variables:
-* \code{WORKER_ID} this is the id field
-* \code{TASK_ID} this is the task id
+* \code{RRQ_WORKER_ID} this is the id field
+* \code{RRQ_TASK_ID} this is the task id
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{rrq_worker$task_eval(task_id)}\if{html}{\out{</div>}}
 }

--- a/man/rrq_worker.Rd
+++ b/man/rrq_worker.Rd
@@ -125,10 +125,6 @@ format to screen and a machine-readable format to the redis database.
 Load the worker environment by creating a new
 environment object and running the create hook (if configured).
 See \code{\link[=rrq_worker_envir_set]{rrq_worker_envir_set()}} for details.
-Some environment variables are created by default:
-* \code{WORKER_ID} - same as \code{id} field
-* \code{WORKER_CONFIG} - same as \code{config} field
-* \code{WORKER_CONTROLLER} - same as \code{controller} field
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{rrq_worker$load_envir()}\if{html}{\out{</div>}}
 }
@@ -252,7 +248,10 @@ progress messages have made it to the server.}
 \if{html}{\out{<a id="method-rrq_worker-task_eval"></a>}}
 \if{latex}{\out{\hypertarget{method-rrq_worker-task_eval}{}}}
 \subsection{Method \code{task_eval()}}{
-Evaluate a task
+Evaluate a task. When running a task on a separate
+process, we will always set two environment variables:
+* \code{WORKER_ID} this is the id field
+* \code{TASK_ID} this is the task id
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{rrq_worker$task_eval(task_id)}\if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -262,10 +262,7 @@ test_that("change environment", {
   w$step(TRUE)
 
   envir <- r6_private(w)$envir
-  expect_equal(ls(envir), c("WORKER_CONFIG", "WORKER_CONTROLLER", "WORKER_ID"))
-  expect_equal(envir$WORKER_ID, w$id)
-  expect_equal(envir$WORKER_CONTROLLER, w$controller)
-  expect_equal(envir$WORKER_CONFIG, w$config)
+  expect_equal(ls(envir), character(0))
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -260,9 +260,7 @@ test_that("change environment", {
 
   obj$envir(NULL)
   w$step(TRUE)
-
-  envir <- r6_private(w)$envir
-  expect_equal(ls(envir), character(0))
+  expect_equal(ls(r6_private(w)$envir), character(0))
 })
 
 

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -260,7 +260,12 @@ test_that("change environment", {
 
   obj$envir(NULL)
   w$step(TRUE)
-  expect_equal(ls(r6_private(w)$envir), character(0))
+
+  envir <- r6_private(w)$envir
+  expect_equal(ls(envir), c("WORKER_CONFIG", "WORKER_CONTROLLER", "WORKER_ID"))
+  expect_equal(envir$WORKER_ID, w$id)
+  expect_equal(envir$WORKER_CONTROLLER, w$controller)
+  expect_equal(envir$WORKER_CONFIG, w$config)
 })
 
 


### PR DESCRIPTION
For orderly runner we would like the worker to know its own worker id since our file structure in the orderly root is `.packit/workers/<worker-id>`.