### PR TITLE
Small doc fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
 Description: Simple Redis queue in R.
 License: MIT + file LICENSE
 LazyData: true
-URL: https://github.com/mrc-ide/rrq, https://mrc-ide.github.io/rrq
+URL: https://mrc-ide.github.io/rrq, https://github.com/mrc-ide/rrq
 BugReports: https://github.com/mrc-ide/rrq/issues
 Imports:
     R6,

--- a/README.Rmd
+++ b/README.Rmd
@@ -83,7 +83,7 @@ Install from the mrc-ide R universe package repository:
 
 ```r
 install.packages(
-  "hipercow",
+  "rrq",
   repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -79,11 +79,12 @@ rrq_destroy(timeout_worker_stop = 10)
 
 ## Installation
 
-Install from the mrc-ide package repository:
+Install from the mrc-ide R universe package repository:
 
 ```r
-drat:::add("mrc-ide")
-install.packages("rrq")
+install.packages(
+  "hipercow",
+  repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 Alternatively, install with `remotes`:

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ For more information, see `vignette("rrq")`
 
 ## Installation
 
-Install from the mrc-ide package repository:
+Install from the mrc-ide R universe package repository:
 
 ```r
-drat:::add("mrc-ide")
-install.packages("rrq")
+install.packages(
+  "hipercow",
+  repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 
 Alternatively, install with `remotes`:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Install from the mrc-ide R universe package repository:
 
 ```r
 install.packages(
-  "hipercow",
+  "rrq",
   repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 


### PR DESCRIPTION
I noticed this when working with Cosmo. 

Reordering the description is a vain attempt to get autolinking from hipercow working - see https://pkgdown.r-lib.org/articles/linking.html - the issue here is that https://mrc-ide.github.io/hipercow/reference/hipercow_rrq_controller.html does not link to our site but to the rdrr.io site.  We may have to manually update hipercow links if we can't get that working...