### PR TITLE
stderr logging fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.7.17
+Version: 0.7.18
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/worker_run.R
+++ b/R/worker_run.R
@@ -119,7 +119,7 @@ worker_run_task_separate_process <- function(task, worker, private) {
     package = "rrq",
     supervise = TRUE,
     stdout = logfile,
-    stderr = logfile,
+    stderr = "2>&1",
     env = c(callr::rcmd_safe_env(),
             RRQ_WORKER_ID = worker_id,
             RRQ_TASK_ID = task_id))

--- a/R/worker_spawn.R
+++ b/R/worker_spawn.R
@@ -168,7 +168,7 @@ rrq_worker_manager <- R6::R6Class(
             w$loop()
           },
           args = args_i, package = TRUE, supervise = FALSE, cleanup = FALSE,
-          stdout = logfile[[i]], stderr = logfile[[i]])
+          stdout = logfile[[i]], stderr = "2>&1")
       }
 
       private$controller <- controller


### PR DESCRIPTION
it is suggested by processx documentation that we use `2>&1` to redirect `stderr` to the same file as `stdout`. https://processx.r-lib.org/reference/process.html#method-process-new so just made this change in the relevant places