### PR TITLE
Propagate the offload path to sub-processes.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rrq
 Title: Simple Redis Queue
-Version: 0.7.20
+Version: 0.7.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -974,6 +974,23 @@ test_that("can inspect a queue without access to the offload", {
 })
 
 
+test_that("can use offload from a separate process", {
+  path <- tempfile()
+  obj <- test_rrq(offload_threshold_size = 100, offload_path = path)
+  w <- test_worker_blocking(obj, offload_path = path)
+
+  data <- runif(20)
+  t <- rrq_task_create_expr(data * 2, separate_process = TRUE,
+                            controller = obj)
+
+  expect_length(dir(path), 1)
+  w$step(TRUE)
+  expect_length(dir(path), 2)
+
+  expect_equal(rrq_task_result(t, controller = obj), data * 2)
+})
+
+
 test_that("collect times", {
   obj <- test_rrq("myfuns.R")
   w <- test_worker_blocking(obj)


### PR DESCRIPTION
When a task is run in a separate process, a new rrq_worker object and controller are created in the sub-process. These need to be configured to use the right offload directory.

It's not obvious to me that the sub-process even needs to interact with Redis and the offload directory. It could very well let the main worker process load the task data and receive it in its arguments, letting callr handle the transfer. In fact that's already how the result is handled, it get returned by the subprocess and written to the offload storage by the parent process.